### PR TITLE
Jsolson Explorer engine rebalance

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Sargent_11x.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Sargent_11x.cfg
@@ -48,7 +48,7 @@ description = A cluster of 11 Vicenza solid rocket motors. It features BDB's Saf
 attachRules = 1,0,1,1,1
 
 // --- standard part parameters ---
-mass = 0.0569
+mass = 0.2288
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.1
@@ -77,7 +77,7 @@ MODULE
 	exhaustDamage = False
 	ignitionThreshold = 0.1
 	minThrust = 0
-	maxThrust = 24.2
+	maxThrust = 61.6
 	heatProduction = 10
 	useEngineResponseTime = True
 	engineAccelerationSpeed = 8.0
@@ -91,8 +91,8 @@ MODULE
 	}
 	atmosphereCurve
  	{
-   	 key = 0 195
-  	 key = 1 174
+   	 key = 0 154
+  	 key = 1 118
  	}
 	
 }

--- a/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Sargent_1x.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Sargent_1x.cfg
@@ -44,7 +44,7 @@ description = Small 0.125m solid rocket booster. It features BDB's SafeSolid™ 
 attachRules = 1,1,1,1,1
 
 // --- standard part parameters ---
-mass = 0.0052
+mass = 0.0208
 dragModelType = default
 maximum_drag = 0.1
 minimum_drag = 0.1
@@ -73,7 +73,7 @@ MODULE
 	exhaustDamage = False
 	ignitionThreshold = 0.1
 	minThrust = 0
-	maxThrust = 2.2
+	maxThrust = 5.6
 	heatProduction = 2
 	useEngineResponseTime = True
 	engineAccelerationSpeed = 8.0
@@ -87,8 +87,8 @@ MODULE
 	}
 	atmosphereCurve
  	{
-   	 key = 0 195
-  	 key = 1 174
+   	 key = 0 154
+  	 key = 1 118
  	}
 	
 }

--- a/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Sargent_3x.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Sargent_3x.cfg
@@ -45,7 +45,7 @@ description = A cluster of 3 Vicenza solid rocket motors.  It features BDB's Saf
 attachRules = 1,0,1,1,1
 
 // --- standard part parameters ---
-mass = 0.0155
+mass = 0.0624
 dragModelType = default
 maximum_drag = 0.1
 minimum_drag = 0.1
@@ -74,7 +74,7 @@ MODULE
 	exhaustDamage = False
 	ignitionThreshold = 0.1
 	minThrust = 0
-	maxThrust = 6.6
+	maxThrust = 16.8
 	heatProduction = 5
 	useEngineResponseTime = True
 	engineAccelerationSpeed = 8.0
@@ -88,8 +88,8 @@ MODULE
 	}
 	atmosphereCurve
  	{
-   	 key = 0 195
-  	 key = 1 174
+   	 key = 0 154
+  	 key = 1 118
  	}
 	
 }


### PR DESCRIPTION
CW: Merge when safe. We're stepping on each other.

Explorer 1x/3x/11x vehicle:
Increased motor dry mass by 4x.
Decreased Isp to match separatron.
Increased thrust for 6 second burn - I'm on the fence on this, 20 secs might be better.

Total vehicle mass: 0.745 ton
Total vehicle Delta V: 1443

Firing engines at apoapsis on a steep suborbital trajectory orbits without going to Jool.