### PR TITLE
Updated Science Definitions

### DIFF
--- a/Gamedata/Bluedog_DB/Resources/ScienceDefs.cfg
+++ b/Gamedata/Bluedog_DB/Resources/ScienceDefs.cfg
@@ -12,24 +12,59 @@ EXPERIMENT_DEFINITION
 	{
 		default = All's quiet. Looks like nothing's going t- PING!
 		default = There might have been an impact recently, but you weren't paying attention.
+		default = The hole beside the impactor COULD be a test result but you're too busy stopping explosive decompression to find out.
+		
 		KerbinInSpaceLow = IMPACT... looks like everything is still in one piece, thankfully. It seems that spacecraft can survive debris impacts, but we should make sure our vessels are shielded.
+		KerbinInSpaceLow = When the mun hits your eye like a big pizza pie...that's an impact!
 		KerbinInSpaceHigh = The detector has logged fewer impacts since attaining a higher orbit.
+				
 		MunInSpaceLow = It appears the Mun had a smaller moon orbiting it - oh. It's gone. 
+		MunInSpaceHigh = So those tiny pinging sounds?  Yeah, that was your science result announcing its arrival.
+		
 		MinmusInSpaceLow = Based on recent impacts, you believe Minmus is challenging you to a snowball fight.
+		MinmusInSpaceHigh = All these tiny paticles kind of reminds you of sprinkles on an ice cream cone...
+		
 		MohoInSpaceLow = Kerbol must have blasted a piece of rock off Moho.
+		MohoInSpaceHigh = We've discovered a new body orbiting Moho and we're calling it Mohoteor...uh...well, it was there for an instant.
+	
 		EveInSpaceLow = Whoa! Looks like the detector just passed through a meteor shower!
-		GillyInSpace = That might have been Gilly's even smaller brother...
+		EveInSpaceHigh = Purple planets, purple clouds, purple dust...what the hell are they putting in the food?
+		
+		GillyInSpaceLow = That might have been Gilly's even smaller brother...
+		GillyInSpaceHigh = Was the rock that just hit you smaller or larger than Gilly?  Not sure...
+		
 		DunaInSpaceLow = Yikes! It seems you weren't expecting that impact... or were you?
+		DunaInSpaceHigh = It seems like dunaroids are just like any other meteroid.  Hard as rock and out to kill you at every opportunity
+		
 		IkeInSpaceLow = You ask Wehrner if that was the famous magic boulder... Or at least a piece of it.
+		IkeInSpaceHigh = Well Ike is here but I don't see Mike anywhere.  What's that splatter on the detector?
+		
 		DresInSpaceLow = You stopped counting the number of impacts soon after you arrived at Dres.
+		DresInSpaceHigh = If Dres isn't trying to kill you why are there 42 hull patches and no hits on the detector?
+		
 		JoolInSpaceLow = It seems that the orbits of any small debris decayed into the gas giant long ago- PING!
+		JoolInSpaceHigh = Apparently even the particles are bigger at Jool...
+		
 		LaytheInSpaceLow = That impact seemed decidedly... moist.
+		LaytheInSpaceHigh = It appears that Laythe has offcially sneezed on your detector.  Congratulations on being to first to discover space boogers!
+		
 		VallInSpaceLow = Yet another impact... so what?
+		VallInSpaceHigh = In sector 637-K the particles are fine and grainy but here they are more coarse.  I think we found...dirt!
+		
 		TyloInSpaceLow = The device measures a large impact, followed by many smaller impacts.
-		BopInSpaceLow = Mission control assures you that you did not, in fact, just collide with Bop.
+		TyloInSpaceHigh = That sound was not the result of an impact but rather was directly caused by space food.  KLANG!  THAT was in impact!
+		
+		BopInSpaceLow = Flight, Mission Control. You did not, in fact, just collide with Bop.
+		BopInSpaceHigh = Mission Control, Flight.  Did we just collode with Bop?
+		
 		PolInSpaceLow = Judging from the impact, we may have impacted something crystalline in nature. 
+		PolInSpaceHigh = Pol, polled politely, properly produced predicted principles of impacts.
+		
 		EelooInSpaceLow = Even out here, it seems spacecraft have to deal with space debris.
+		EelooInSpaceHigh = We came, we saw, we got hit by more rocks.
+		
 		AsteroidInSpaceLow = Pieces of the asteroid seem to have broken off from the activity around it...
+		AsteroidInSpaceHigh = WAIT!  No one said anything about rocks around the rock.
 		AsteroidSrfLanded = The detector pings angrily as it is pelted from the debris of our landing.
 	}
 }
@@ -82,7 +117,7 @@ EXPERIMENT_DEFINITION
 }
 
 EXPERIMENT_DEFINITION
-{	
+{
 	id = bd_massSpec
 	title = Mass Spectrum Analysis
 	baseValue = 8
@@ -93,7 +128,76 @@ EXPERIMENT_DEFINITION
 	biomeMask = 1
 	RESULTS
 	{
-	default = You analyze the composition of the atmosphere as it passes through the spectrometer.
+	 default = You analyze the composition of the atmosphere as it passes through the spectrometer.
+	 default = Various elements such as nitrogen, carbon and oxygen are present in your readings along with other trace elements.
+	 default = The slight variations in elemental levels here will require a longer term analysis but at least you got a basic reading.
+	 
+	 KerbinInSpaceLow = Strong lines of oxygen and nitrogen combine with trace readings of carbon dioxide, ozone, hydrogen and many others.
+	 KerbinSrfLandedLaunchPad = Heavy lines of oxygen, methane, complex hydrocarbons and numerous corrosive and poisonous substances from fuel leaks are present in this location.
+	 KerbinSrfLanded = The oxygen and nitrogen that is ever present is joined by a strong carbon line.
+	 KerbinSrfLandedIceCaps = Heavy levels of water are present in the readings.  Not surprising since you're landed on a big chunk of water...
+	 KerbinSrfLandedMountains = Metals of various types show up in trace quantities from the exposed mountainsides and raised rock from below the surface of the planet.
+	 KerbinSrfLandedBadlands = Some small levels of actual radioactive isotopes show up in minute quantities here.  Could be worth more checking?
+	 KerbinSrfLandedRunway = The heavy pollution of leaked jet fuel nearly clogs the intake sensor making reading here very difficult.
+	 KerbinSrfLandedFlagPole = It's a flag pole.  What kind of actual science do you think it's going to give you?  
+	 KerbinSrfLandedTrackingStation = Look at the satellite dish!  It's made of metal but the spectrometer doesn't detect it...hmmm...kick it!
+	 KerbinSrfLandedVAB = This large metal building houses the legendary Kraken.  The spectrometer refuses to give any readings here out of fear.
+	 KerbinSrfLandedR&D = Strong levels of methane and a lingering odor is detected from all the decaying BS2.
+	 KerbinSrfLandedAdministration = A complex form of BS known as Poly(TiCaLi)-BS2 is strongly detected near this location.
+	 KerbinSrfLandedAstronautComplex = High levels of neon are present, but that could be the gigantic sign advertising Jeb's new nightclub inside the complex that could be throwing off the results.
+	 KerbinSrfLandedSPH = The VAB is rumored to be the home of the Kraken but it summers at the SPH.  The spectrometer doesn't work here either.
+	 KerbinSrfLandedMissionControl = Rumors abound that money is paid for results in this locaiton.  You get the most precise readings of BS yet.
+	
+	 MunInSpaceLow = Carbonate and silicate dust particles from the Mun's surface show as strong lines on the results from this altitude
+	 MunSrfLanded = Various hydroxides, oxides and nitrates are detectable behind the ever present signs of carbonate and silicate deposits
+	 MunSrfLandedNorthernBasin = Ino- and sorosilicate detections appear stronger in the basin than without
+	 MunSrfLandedPolarCrater = High levels of irridium left over from the impact are detectable in all samples from this crater
+	 MunSrfLandedHighlandCraters = Isotope readings combined with the spectroscopy show this region to be slightly younger than most others
+	 MunSrfLandedEastFarsideCrater = Trace readings of water are detected in some of the darker regions of the large crater
+	 MunSrfLandedPoles = While not overwhelming, water can be detected in the polar readings.  Further study would be needed to determine if these are viable for colony support.
+	
+	 MinmusInSpaceLow = Numerous hydrates and high levels of water can be easilyly detected at these altidudes
+	 MinmusSrfLanded = As has long been expected, high levels of frozen water, nitrogen and methane are present along with strong salt lines.
+	 MinmusSrfLandedGreaterFlats = Readings from here show that several different major salts make up the bulk of the salinization lines present in the spectroscopic readings
+	 MinmusSrfLandedLesserFlats = Strangely the salinity is not as strong here allowing more precise chemistry makeups to be identified from this location
+	
+	 SunInSpaceLow = The hydrogen and helium lines nearly overwhelm the detectors at this point which are already unstable due to high heat levels
+	
+	 MohoInSpaceLow = It appears the detectors caught a whiff of iron vapor it's so hot here
+	 MohoSrfLanded = Surface readings are littered with isotopes deposited by the sun but high levels of carbonates and silicates are present behind those results.
+	
+	 EveInSpaceLow = VERY heavy levels of carbon dioxide are present along with signigicant complex hydrocarbons
+	 EveSrfLanded = Once the carbon dioxide is filtered out of the readings, ethane along with other complex, possibly volatile hydrocarbons
+	
+	 GillyInSpaceLow = Carbon, oxygen and carbon dioxide are all present in the readings along with the expected signs of silicates and carbonates
+	 GillySrfLanded = Once landed, the levels of carbon spike considerably higher helping to confirm the theory that Gilly's core is mostly carbon
+	
+	 DunaInSpaceLow = Low levels of carbon dioxide and traces of nitrogen and methane are detected by the detectors
+	 DunaSrfLanded = Atmospheric carbon dioxide is easily detectable from the surface and additional readings show several isotopes that were unexpected.
+	
+	 IkeInSpaceLow = Ike is so large and orbits so close to Duna the planet's carbon dioxide atmosphere litters the spectroscopic results with carbon and oxygen detections.
+	 IkeSrfLanded = Molecular carbon and oxygen are still heavily detected but surface results provide strong readings geologists will be able to use to determine Ike's chemical makeup.
+	
+	 DresInSpaceLow = Spectroscopic results indicate a large presence of silicate and carbonate dust around the planet possibly coming from the local asteroid ring.
+	 DresSrfLanded = Surface scans show Dres contains the presence of water ice throughout its crust and seem to indicate most cratering on the planet likely was the result of impacts from the local asteroid field.
+	
+	 JoolInSpaceLow = Strong detection lines of hydrogen and helium are present along with a number of H/He isotopes.  A fair amount of ammonia was expected but was not found.
+	 LaytheInSpaceLow = Water, oxygen and various salts were expected.  The presence of trace amounts of chlorine was not.
+	 LaytheSrfLanded = Surface scans confirm the waters of Laythe to contain high levels of salinity.  Atmospheric results also show ozone and trace amounts of chlorine making it completely unbreathable.
+	 VallInSpaceLow = Water and nitrogen are both showing up strongly in the scanners results from orbit.
+	 VallSrfLanded = The chemical makeup of the water at the surface suggest there are likely liquid oceans beneath the frozen outer layers of the moon.
+	 TyloInSpaceLow = Very small traces of water ice is present along with high levels of silicate and carbonate dust in samples from orbit.
+	 TyloSrfLanded = Tiny traces of water can be found along with high levels of various metals including nickel and cobalt.
+	 BopInSpaceLow = The gravity of Bop is so low the orbital region is polluted by hydrogen and helium from Jool.
+	 BopSrfLanded = Surface scans reveal high concentrations of both carbon and iron oxide giving the moon its dark coloration.
+	 PolInSpaceLow = With its distance from Jool, sulfur and phosphor from the surface can be detected from orbit.
+	 PolSrfLanded = High concentrations of sulfur and sulfuric compounds along with high levels of phosphates leave the formation theories of Pol in flux and unconfirmed.
+	
+	 EelooInSpaceLow = Scans indicate the presence of nitrogen and methane in concentrations high enough to represent a very tenuous atmosphere but not enough to affect apacecraft in a measurable way.
+	 EelooSrfLanded = Spectroscopic scans of the surface show high levels of water ice and frozen nitrogen and methane.  They also indicate the surface is renewed or eroded in some way over time.
+	
+	 AsteroidInSpaceLow = Trace amounts of water along with silicate and carbonate compounds are found in most asteroids
+	 AsteroidSrfLanded = Scans confirm the presence of tiny amounts of water ice along with high concentrations of metals and minerals.
 	}
 }
 


### PR DESCRIPTION
 - Expanded definitions for the Micrometeroid Experiment to cover all stock bodies for both high and low orbits

 - Added full definitions for the Quadropole Mass Spectrometer including partial landed biome definitions for Kerbin, Mun and Minmus.  All bodies now have at least 'In Space Low' and 'Landed' definitions.

I have tested these on my save game along with other experiment sets and have found no errors that kill any experiments yet.