### PR TITLE
Latest updates to several files

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/AntennaRange/AR_BDB-OPM.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/AntennaRange/AR_BDB-OPM.cfg
@@ -253,7 +253,7 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@name = ModuleLimitedDataTransmitter
-		@packetInterval = 0.65
+		@packetInterval = 0.75
 		@packetSize = 1.4
 		@packetResourceCost = 11.0
 		nominalRange = 2850000
@@ -280,11 +280,37 @@
 	{
 		@name = ModuleLimitedDataTransmitter
 		@packetInterval = 0.5
-		@packetSize = 1.15
-		@packetResourceCost = 9.0
+		@packetSize = 0.95
+		@packetResourceCost = 8.0
 		nominalRange = 48000000
 		simpleRange = 7135242690
 		maxPowerFactor = 2
+		maxDataFactor = 2
+	}
+
+	MODULE
+	{
+		name = ModuleScienceContainer
+
+		dataIsCollectable = true
+		dataIsStorable = false
+
+		storageRange = 2
+	}
+}
+
+//A27-C Dish
+@PART[bluedog_mariner4Dish]:NEEDS[AntennaRange&Bluedog_DB&OPM,!RemoteTech]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleLimitedDataTransmitter
+		@packetInterval = 0.5
+		@packetSize = 1.70
+		@packetResourceCost = 14.0
+		nominalRange = 180000000
+		simpleRange = 9770333436
+		maxPowerFactor = 4
 		maxDataFactor = 3
 	}
 
@@ -305,12 +331,12 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@name = ModuleLimitedDataTransmitter
-		@packetInterval = 0.5
-		@packetSize = 2.2
+		@packetInterval = 0.65
+		@packetSize = 1.2
 		@packetResourceCost = 9.0
-		nominalRange = 195500000
-		simpleRange = 11757524217
-		maxPowerFactor = 3
+		nominalRange = 295000000
+		simpleRange = 17688831241
+		maxPowerFactor = 2
 		maxDataFactor = 2
 	}
 
@@ -331,13 +357,13 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@name = ModuleLimitedDataTransmitter
-		@packetInterval = 0.35
-		@packetSize = 4.5
-		@packetResourceCost = 11.0
+		@packetInterval = 0.55
+		@packetSize = 1.75
+		@packetResourceCost = 15.0
 		nominalRange = 595000000
-		simpleRange = 20511668260
-		maxPowerFactor = 3
-		maxDataFactor = 2
+		simpleRange = 17763625787
+		maxPowerFactor = 4
+		maxDataFactor = 4
 	}
 
 	MODULE
@@ -358,12 +384,12 @@
 	{
 		@name = ModuleLimitedDataTransmitter
 		@packetInterval = 0.85
-		@packetSize = 1.75
-		@packetResourceCost = 9.5
+		@packetSize = 1.55
+		@packetResourceCost = 9.0
 		nominalRange = 850000000
 		simpleRange = 30026007827
 		maxPowerFactor = 2
-		maxDataFactor = 5
+		maxDataFactor = 3
 	}
 
 	MODULE
@@ -383,7 +409,9 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@name = ModuleLimitedDataTransmitter
-		@packetInterval = 0.45
+		@packetInterval = 0.25
+		@packetSize = 1.15
+		@packetResourceCost = 16.0
 		nominalRange = 1750000000
 		simpleRange = 43083120832
 		maxPowerFactor = 2
@@ -408,8 +436,8 @@
 	{
 		@name = ModuleLimitedDataTransmitter
 		@packetInterval = 0.45
-		@packetSize = 3.5
-		@packetResourceCost = 12.0
+		@packetSize = 1.60
+		@packetResourceCost = 16.0
 		nominalRange = 3645000000
 		simpleRange = 35898497304
 		maxPowerFactor = 6
@@ -433,8 +461,8 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@name = ModuleLimitedDataTransmitter
-		@packetInterval = 0.55
-		@packetSize = 2.5
+		@packetInterval = 0.65
+		@packetSize = 1.65
 		@packetResourceCost = 9.0
 		nominalRange = 3650000000
 		simpleRange = 62220652737
@@ -491,7 +519,7 @@
 		nominalRange = 39600000000
 		simpleRange = 144917464100
 		maxPowerFactor = 4
-		maxDataFactor = 6
+		maxDataFactor = 4
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Compatibility/AntennaRange/AR_BDB-Stock.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/AntennaRange/AR_BDB-Stock.cfg
@@ -255,9 +255,37 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@name = ModuleLimitedDataTransmitter
+		@packetResourceCost = 8.0
+		@packetInterval = 0.85
 		nominalRange = 64000000
-		simpleRange = 3363585661
-		maxPowerFactor = 4
+		simpleRange = 3883934174
+		maxPowerFactor = 3
+		maxDataFactor = 3
+	}
+
+	MODULE
+	{
+		name = ModuleScienceContainer
+
+		dataIsCollectable = true
+		dataIsStorable = false
+
+		storageRange = 2
+	}
+}
+
+//A27-C Dish
+@PART[bluedog_mariner4Dish]:NEEDS[AntennaRange&Bluedog_DB,!RemoteTech,!OPM]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleLimitedDataTransmitter
+		@packetSize = 0.95
+		@packetResourceCost = 8.5
+		@packetInterval = 0.40
+		nominalRange = 125000000
+		simpleRange = 5427963020
+		maxPowerFactor = 3
 		maxDataFactor = 4
 	}
 
@@ -278,10 +306,14 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@name = ModuleLimitedDataTransmitter
+		@packetSize = 1.50
+		@packetResourceCost = 10.0
+		@packetInterval = 0.85
+
 		nominalRange = 257500000
 		simpleRange = 6746851046
 		maxPowerFactor = 4
-		maxDataFactor = 4
+		maxDataFactor = 3
 	}
 
 	MODULE
@@ -301,11 +333,13 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@name = ModuleLimitedDataTransmitter
-		@packetInterval = 0.35
+		@packetSize = 2.45
+		@packetResourceCost = 20.0
+		@packetInterval = 1.05
 		nominalRange = 595000000
-		simpleRange = 8373853502
-		maxPowerFactor = 6
-		maxDataFactor = 2
+		simpleRange = 10255834130
+		maxPowerFactor = 4
+		maxDataFactor = 4
 	}
 
 	MODULE
@@ -325,11 +359,12 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@name = ModuleLimitedDataTransmitter
-		@packetInterval = 0.90
+		@packetSize = 1.75
 		@packetResourceCost = 10.0
-		nominalRange = 850000000
-		simpleRange = 10963947866
-		maxPowerFactor = 5
+		@packetInterval = 0.95
+		nominalRange = 790000000
+		simpleRange = 13645687440
+		maxPowerFactor = 3
 		maxDataFactor = 4
 	}
 

--- a/Gamedata/Bluedog_DB/Compatibility/CommunityTechTree/CTT.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/CommunityTechTree/CTT.cfg
@@ -30,7 +30,7 @@
 
 @PART[bluedog_MOL_Lab]:NEEDS[CommunityTechTree]
 {
-	@TechRequired = advExploration
+	@TechRequired = advRocketry
 }
 
 @PART[bluedog_atlas1AdapterTank]:NEEDS[CommunityTechTree]
@@ -141,11 +141,6 @@
 @PART[bluedog_LOdish]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = electrics
-}
-
-@PART[bluedog_cameraHighTech]:NEEDS[CommunityTechTree]
-{
-	@TechRequired = electronics
 }
 
 @PART[bluedog_domeAntenna]:NEEDS[CommunityTechTree]
@@ -288,6 +283,11 @@
 	@TechRequired = propulsionSystems
 }
 
+@PART[bluedog_Gemini_MalhenaSM]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = propulsionSystems
+}
+
 @PART[bluedog_Gemini_LanderCan]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = simpleCommandModules
@@ -331,4 +331,24 @@
 @PART[bluedog_125mFairing]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = stability
+}
+
+@PART[bluedog_MOL_KISmodule]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = specializedConstruction
+}
+
+@PART[bluedog_MOL_UnpressurizedCargo]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[bluedog_Saturn_S1_Retro]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = precisionPropulsion
+}
+
+@PART[bluedog_Titan1_FuelTank3]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
 }

--- a/Gamedata/Bluedog_DB/Compatibility/CommunityTechTree/CTT.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/CommunityTechTree/CTT.cfg
@@ -1,0 +1,334 @@
+@PART[bluedog_Saturn_25mFairingBase]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advAerodynamics
+}
+
+@PART[bluedog_Saturn_3125mFairingBase]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advAerodynamics
+}
+
+@PART[bluedog_Titan2_17mFairing]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advConstruction
+}
+
+@PART[bluedog_MOL_Adapter_1875_15]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advConstruction
+}
+
+@PART[bluedog_centaur1875mAdapterFairing]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advConstruction
+}
+
+@PART[bluedog_centaur25mAdapterFairing]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advConstruction
+}
+
+@PART[bluedog_MOL_Lab]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advExploration
+}
+
+@PART[bluedog_atlas1AdapterTank]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_atlas1LongTank]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_atlas1MediumTank]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_atlas1ShortTank]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_atlasBooster]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_atlasFairingAdapterTank]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_atlasSustainer]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_H1D]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_LR87_mod1]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_LR91_mod1]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_Titan1_FuelTank1]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_Titan1_FuelTank2]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_Titan1_BigAdapterMedium]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_LR87_SingleChamber]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_Soltan_SRBnose]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advRocketry
+}
+
+@PART[bluedog_MOL_ControlSegment]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advUnmanned
+}
+
+@PART[bluedog_Saturn_S4_InstrumentUnit]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advUnmanned
+}
+
+@PART[bluedog_Titan1_15mFairing]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = aviation
+}
+
+@PART[bluedog_telstar]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = basicScience
+}
+
+@PART[Gemini_Crew_B]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = commandModules
+}
+
+@PART[bluedog_scimitar]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = electrics
+}
+
+@PART[bluedog_LOdish]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = electrics
+}
+
+@PART[bluedog_cameraHighTech]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = electronics
+}
+
+@PART[bluedog_domeAntenna]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = electronics
+}
+
+@PART[bluedog_agenaAntenna]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = engineering101
+}
+
+@PART[bluedog_atlasVernier]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = flightControl
+}
+
+@PART[bluedog_stackVernier]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = flightControl
+}
+
+@PART[bluedog_Titan2_1875mDecoupler]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[bluedog_agenaPort]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[bd_gemini_cap]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[Gemini_Port_A]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[bluedog_Titan1_BigAdapterShort]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[bluedog_Titan1_SmallAdapter]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[bluedog_MOL_Adapter_15_125]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[bluedog_atlasBoosterFairing]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[bluedog_atlasDecoupler]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = generalConstruction
+}
+
+@PART[bluedog_AtlasVCCB_LowerTank]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = heavierRocketry
+}
+
+@PART[bluedog_AtlasVCCB_UpperTank]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = heavierRocketry
+}
+
+@PART[bluedog_Titan_SRB2seg]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = heavyRocketry
+}
+
+@PART[bluedog_MOL_Solar2]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = largeElectrics
+}
+
+@PART[Gemini_Heatshield_B]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = landing
+}
+
+@PART[bluedog_Saturn_S1_EngineMount]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = largeVolumeContainment
+}
+
+@PART[bluedog_Saturn_S1_Tankage]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = largeVolumeContainment
+}
+
+@PART[bluedog_Saturn_S4_AdapterTank]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = largeVolumeContainment
+}
+
+@PART[bluedog_Saturn_S4_EngineMount]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = largeVolumeContainment
+}
+
+@PART[bluedog_Saturn_S4_Tankage]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = largeVolumeContainment
+}
+
+@PART[bluedog_mariner4Antenna]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = miniaturization
+}
+
+@PART[bluedog_MOL_rackDish]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = precisionEngineering
+}
+
+@PART[bluedog_Saturn_S4_Ullage]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = precisionPropulsion
+}
+
+@PART[bluedog_Titan_TranstageEngine]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = propulsionSystems
+}
+
+@PART[bluedog_Titan_TranstageTank]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = propulsionSystems
+}
+
+@PART[bluedog_Gemini_LanderCan]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = simpleCommandModules
+}
+
+@PART[Gemini_Crew_A]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = simpleCommandModules
+}
+
+@PART[bluedog_IRspec]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = spaceExploration
+}
+
+@PART[bluedog_Saturn_S4_Interstage]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = specializedConstruction
+}
+
+@PART[bluedog_MOL_DockingPort]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = specializedConstruction
+}
+
+@PART[bluedog_Saturn_S1_AdvancedFin]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = specializedControl
+}
+
+@PART[bluedog_Saturn_S1_LargeFin]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = specializedControl
+}
+
+@PART[bluedog_Saturn_S1_SmallFin]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = specializedControl
+}
+
+@PART[bluedog_125mFairing]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = stability
+}

--- a/Gamedata/Bluedog_DB/Parts/Science/bluedog_cameraHighTech.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Science/bluedog_cameraHighTech.cfg
@@ -10,7 +10,7 @@ MODEL
 	scale = 1
 	rescaleFactor = 1
 	node_attach = 0.0, -0.05480693, 0.02, 0.0, -1.0, 0.0
-	TechRequired = scienceTech
+	TechRequired = advScienceTech
 	entryCost = 10000
 	cost = 1000
 	category = Science
@@ -19,7 +19,7 @@ MODEL
 	manufacturer = Bluedog Design Bureau
 	description = This camera replaces the film with a digital imaging sensor we stole from our former partners over at Codac. They weren't going to use it anyways. Because this new imager is completely digital, the entire image can be transmitted back to Kerbin.
 	attachRules = 0,1,0,0,1
-	mass = 0.05
+	mass = 0.025
 	dragModelType = default
 	maximum_drag = 0.1
 	minimum_drag = 0.1
@@ -78,7 +78,7 @@ MODEL
     asteroidReports = true		        //Default = false	        //Do you want to be able to collect results while landed on and/or near an asteroid
 	planetaryMask = 524287			//Default = 524287		//Bitmask defining which planets the experiment can be performed on/around, works everywhere by default
 	planetFailMessage = Can't conduct experiment here  	//Default = Can't conduct experiment here 		//Message to be displayed if the experiment can't be performed on the current planet/moon
-	experimentsLimit = 4          	//Default = 1		//Sets the limit for how many experiments can be collected and stored by an individual part
+	experimentsLimit = 0          	//Default = 1		//Sets the limit for how many experiments can be collected and stored by an individual part
 	externalDeploy = true			//Default = false	//Allow the experiment to be triggered by an EVA Kerbal; still requires power if applicable
     excludeAtmosphere = false			//Default = false	//Specify experiments that can only run on planets/moons without an atmosphere
 

--- a/Gamedata/Bluedog_DB/Parts/Science/bluedog_cameraMidTech.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Science/bluedog_cameraMidTech.cfg
@@ -19,7 +19,7 @@ MODEL
 	manufacturer = Bluedog Design Bureau
 	description =  Film cameras are limited in that the film must be returned to Kerbin in order to be developed. In order to get a better idea of what lies further out in space, we have developed this advanced film camera in conjunction with our partner Codac. After exposing the film, it is developed automatically and then transmitted in strips using a primitive photoscanner. A significant amount of detail is lost in this process, so the images aren't as valuable as actually returning the film. The film is stored after development, and can be still be examined if it happens to be returned.
 	attachRules = 0,1,0,0,1
-	mass = 0.03
+	mass = 0.035
 	dragModelType = default
 	maximum_drag = 0.1
 	minimum_drag = 0.1
@@ -78,7 +78,7 @@ MODEL
     asteroidReports = true		        //Default = false	        //Do you want to be able to collect results while landed on and/or near an asteroid
 	planetaryMask = 524287			//Default = 524287		//Bitmask defining which planets the experiment can be performed on/around, works everywhere by default
 	planetFailMessage = Can't conduct experiment here  	//Default = Can't conduct experiment here 		//Message to be displayed if the experiment can't be performed on the current planet/moon
-	experimentsLimit = 4          	//Default = 1		//Sets the limit for how many experiments can be collected and stored by an individual part
+	experimentsLimit = 6          	//Default = 1		//Sets the limit for how many experiments can be collected and stored by an individual part
 	externalDeploy = true			//Default = false	//Allow the experiment to be triggered by an EVA Kerbal; still requires power if applicable
     excludeAtmosphere = false			//Default = false	//Specify experiments that can only run on planets/moons without an atmosphere
 

--- a/Gamedata/Bluedog_DB/Resources/ScienceDefs.cfg
+++ b/Gamedata/Bluedog_DB/Resources/ScienceDefs.cfg
@@ -214,55 +214,230 @@ EXPERIMENT_DEFINITION
 	RESULTS
 	{
 	default = You take a picture of whatever the camera is pointing at. Pretty.
-	KebolInSpaceHigh = She is very bright and very beautiful. Kerbol, the star that keeps Kerbalkind alive... 
-	KerbolInSpaceLow = The light coming off Kerbol has made the image pure white! You're lucky you didn't damage the camera...
-	MohoInSpaceHigh = Moho floats far away, punished with craters. You can almost see the heat of the home star, Kerbol... 
-	MohoInSpaceLow = Craters become clear on Moho's surface. With immense detail, the craters have craters. This reminds you that you are too close for comfort... 
-	MohoSrfLanded = After your descent, you see the distinct features of the planet. Craters are visible as far as the eye can see. 
-	EveInSpaceHigh = Eve shimmers with its purple hue down below you. Or was it up? You can't remember... 
-	EveInSpaceLow = Eve greets you with great delight as you swoop past, revealing how vast her Explodium Oceans are. You now want a grape popsicle... 
-	EveSrfLanded = The purple sand of this dense planet stretches across the surface. You get hungry and wonder if this sand is toxic if eaten... 
-	GillyInSpaceHigh = Gilly barely resembles a dot in the photo. 
-	GillyInSpaceLow = Gilly, a beige captured asteroid reveals very extreme terrain. A blur in the photo shows its fast rotation. 
-	GillySrfLanded = The photo shows a wide variety of mountains. There is really nothing else here. 
-	KerbinInSpaceHigh = There is something very familiar about all this water and land you see. 
-	KerbinInSpaceLow = Who knew the space agency would be spying on all these Krussians? 
+	
+	SunInSpaceHigh = She is very bright and very beautiful. Kerbol, the star that keeps Kerbalkind alive... 
+	SunInSpaceLow = The light coming off Kerbol has made the image pure white! You're lucky you didn't damage the camera...
+	
+	KerbinSrfLandedAdministration = The administrators grumble about it and most of them aren't smiling but you manage to get a group photo of everyone except Stan whose head you cut off in the frame.
+	KerbinSrfLandedAstronautComplex = The astronauts being who they are begin fighting to see who is going to be in the center of the group photo.  Unsurprisingly, Jeb won.
+	KerbinSrfLandedCrawlerway = The crawlerway is a long slab of concrete but your photo might one day make it into an abstract art gallery.
+	KerbinSrfLandedFlagPole = It's a damned flag pole.  And there's not flag flying today.  So you took a picture of a long metal stick.
+	KerbinSrfLandedLaunchPad = The details around the launch pad will be very popular with people playing the latest computer game - Human Space Program - a very popular game about a fictional race of creatures who go into space.
+	KerbinSrfLandedMissionControl = The pictures from inside mission control were confiscated at the door by a vary large kerbal named Arnold.  You didn't argue.
+	KerbinSrfLandedR&D = At first the researchers were extremely happy to have you photographing their experiments but when you started asking questions about what it revealed they got very angry and told you it was highly technical explosive blow uppie stuff and you wouldn't understand.
+	KerbinSrfLandedR&DCentralBuilding = You now have a picture of a large, unlabelled and unnamed concrete building.
+	KerbinSrfLandedR&DCornerLab = You now have another picture of another large concrete building and it happens to be on a corner.
+	KerbinSrfLandedR&DMainBuilding = Yet another large concrete building.  You would really like to have pictures from inside but the researchers won't let you in since you were asking too many questions they couldn't answer.
+	KerbinSrfLandedR&DObservatory = When you asked if you could attach your camera to the telescope to take some pictures they just looked at you funny.  You did get a good picture of the telescope itself though.
+	KerbinSrfLandedR&DSideLab = Look, another concrete building.  You can tell your grandkids one day some amazing story about something that didn't happen to you at this building.
+	KerbinSrfLandedR&DSmallLab = For just a moment, you thought you saw peering out of the window what appeared to be a tall, vaguely kerbal shaped figure with pinkish-brown skin, a roudn head and nearly 4 times the height of a normal kerbal.  It was disturbing and unfortunately the photo you took was blurred.  No one will believe you.
+	KerbinSrfLandedR&DTanks = It's a large tank filled with something that you are unable to identify and the researchers refuse to tell you what it is.
+	KerbinSrfLandedR&DWindTunnel = The photos of the latest wind tunnel test of the new launch vehicle were confiscated by Arnold the Giant Kerbal again.  Newspapers are reporting a resounding success but you know better.  You just don't have evidence to prove it anymore.  The kerballed test is going forward.
+	KerbinSrfLandedRunway = The photos of landing aircraft you took have turned out extremely well and appeared in Kane's Defense Weekly.
+	KerbinSrfLandedSPH = Several pictures of the latest generation of space planes have made their way into the public and you're being blamed for it.
+	KerbinSrfLandedSPHMainBuilding = You should go back to the runway for more pictures of aircraft.  The photos of large concrete buildings just aren't as interesting.
+	KerbinSrfLandedSPHRoundTank = It's a tank full of jet fuel.  At least the pilots say that it is but secretly you believe this to be the storage vat for Jeb's supply of beer.
+	KerbinSrfLandedSPHTanks = If Jeb's beer isn't in the round tank, it has to be here.  Unfortunately, if you're wrong when you open the tank it will likely mean your death.
+	KerbinSrfLandedSPHWaterTower = On the hunt for Jeb's beer storage tank you have taken photos of the water tower.  Unfortunately Arnold the Giant Kerbal told you to come down halfway in your climb to the top to prove your theory.
+	KerbinSrfLandedTrackingStation = As you start taking photos of the large comm dishes in the area, you see a black government car pull up but no one gets out.  They're just sitting there.  Watching you.
+	KerbinSrfLandedTrackingStationDishEast = The black government car pulls around the corner as you make your way to the east dish.  Maybe your camera is making them nervous.
+	KerbinSrfLandedTrackingStationDishNorth = Four kerbals wearing black suits and ties with dark sunglasses have all gotten out of the car.  One of them is talking to his wrist for some reason while looking directly at you taking your photographs.
+	KerbinSrfLandedTrackingStationDishSouth = As you hurry around the corner to the south dish you run head on into Arnold followed by one of the government suits.  There's a blinding flash of light and when you wake up no one is there, you can't remember anything and your camera is empty of all photos.
+	KerbinSrfLandedTrackingStationHub = You were able to snap a shot of the hub but at the distance you took the picture it looks like nothing more than a mobile home with three large satellite dishes in the front yard.
+	KerbinSrfLandedVAB = The VAB is so tall you had to lay on the ground to fit it in the frame.  You've won a $50 prize for an abstract photo contest with this image.
+	KerbinSrfLandedVABMainBuilding = After winning your $50 photo contest with your other VAB shot you decided to try the same thing again.  Unfortunately this is old hat now and everyone is taking pictures by lying on the ground now.
+	KerbinSrfLandedVABPodMemorial = The memorial is a somber reminder of all the brave souls who came before and gave their lives in service to the greater good.  That's what the researchers and engineers who blew them up say anyway.
+	KerbinSrfLandedVABRoundTank = The hunt for Jeb's beer storage continues...
+	KerbinSrfLandedVABSouthComplex = The engineers chose this location for their group photo.  It was lovely and all 219 asked you to make a copy of it for them.
+	KerbinSrfLandedVABTanks = The ground crew chose this location for their ground photo.  You are nearly positive they were using this as a pretense to protect Jeb's beer storage.
+	KerbinSrfLandedKSC = It really was much easier to fit the entire KSC in an image from the air.  Climbing to the top of the VAB just didn't cut it but you still got a resonably good shot of the grounds.
+	
 	KerbinSrfLanded = Haven't you seen this before? 
-	MunInSpaceHigh = The Mun appears to be very cratered while the lowlands sit pristinely below all of the mountains. 
-	MunInSpaceLow = Closer to the moon now, you see that craters have ravaged the surface. Even the plains are unforgiven, which makes you infer that time has taken its toll on the Mun's surface... 
+	KerbinSrfLandedGrasslands = Large rolling fields of long grass with very few trees create a pastoral image you couldn't pass up.
+	KerbinSrfLandedTundra = The frozen tundra presents a stark view that is both nearly lifeless on a large scale but serenely beautiful.
+	KerbinSrfLandedMountains = The mountain vistas or Kerbin are beautiful to behold and make for some of the best photos you have ever taken.
+	KerbinSrfLandedBadlands = The striation of colors in layered landscapes of the badlands create vivid images at sunset.
+	KerbinSrfLandedDeserts = The rolling dunes, the vast plains of sand broken only by an occasional oasis and the lighting conditions make you feel like Kansel Kadams.
+	KerbinSrfLandedHighlands = Although the kerbals from this area speak with a brogue accent you can barely understand they have nevertheless guided you to locations within the highlands that allow you to bring out their subtle beauty in your photos.
+	KerbinSrfLandedIceCaps = Glaciers, vast ice fields and chasms create a varied landscape which is captured wonderfully in your photos.  Your nose is also frost bitten now.
+	KerbinSrfLandedShores = The photos of the shores you have taken have recently been licensed by a travel company to create brochures to bring tourists to the beach.
+	KerbinSrfLandedWater = While the ocean is beautiful and terrible to behold at times, today it is nearly smooth as glass and you capture reflected sunlight from the surface of the water at sunset creating a lovely image.
+	KerbinSrfLanded = Haven't you seen this before? 
+			KerbinInSpaceLow = Who knew the space agency would be spying on all these Krussians? 
+					KerbinInSpaceHigh = There is something very familiar about all this water and land you see. 
+
+	MunSrfLandedCanyons = Image data of the canyons on the Mun shows it was geologically active at one point in time but no longer.
+	MunSrfLandedEastCrater = Photos of the East Crater are helping to answer some of the fundamental questions regarding the Mun's surface and how it has been affected by large imapacts.
+	MunSrfLandedEastFarsideCrater = Imaging data from this "smaller" impact has proven just as important as that from the large craters around the Mun.
+	MunSrfLandedFarsideCrater = A favorite landing site of many, photographic evidence helps to reveal this crater to be one of the oldest on the surface.
+	MunSrfLandedHighland = The highland regions of the Mun appear to have been formed during a period where the surface of the Mun was still geologically active.
+	MunSrfLandedHighlandCraters = These small impact craters are younger and therefore photographic data helps to answer many questions about the different impact eras of the Mun.
+	MunSrfLandedMidlands = As with other regions on the Mun, imaging data shows the midlands appear to have been thrust upward during a geologically active period on the Mun.
+	MunSrfLandedMidlandCraters = As with other smaller impact regions, the midland craters are shown through photo evidence to be younger than other impact areas around the Mun.
+	MunSrfLandedNorthernBasin = This gigantic basin appears to be the result of molten rock flowing over the surface in the distant past.  Imaging data from the surface does not help to answer what may have caused it to flow in the first place.
+	MunSrfLandedNorthwestCrater = This enormous impact region was formed during the earliest days of the Mun's formation which imaging data will help understand.
+	MunSrfLandedPolarCrater = This high latitude impact region was formed around the same time as the Northwest Crater making it among the oldest areas of the Mun.  Photographic data from this region helps to reveal details of this impact and its aftermath.
+	MunSrfLandedPolarLowlands = The polar lowlands appear to be a region formed during a geologically active period and was affected by the mammoth impact events occuring during that time.  Photographic evidence of this region helps to reveal how these processes interacted.
+	MunSrfLandedPoles = Image data from the poles is helping to answer questions about the formation of the Mun and whether resources that could assist in creating a surface base exists.
+	MunSrfLandedSouthwestCrater = The Southwest Crater was also formed around the same time as the other colossal sized craters on the surface.  Photographic evidence is helping to answer many of the questions surrounding this violent time of the Mun's history.
+	MunSrfLandedTwinCraters = Formed when two bodies in orbit around each other collided with the Mun, photos of the Twin Craters have shown this region to be younger than originally thought				
 	MunSrfLanded = The ground is very grey. Around you, there are slopes and mountains.
-	MinmusInSpaceHigh = From so far away, Minmus resembles a small scoop of mint ice cream... 
-	MinmusInSpaceLow = Minmus reveals varying terrain. High plateaus stretch for kilometres and the plains below them stretch even farther. 
+			MunInSpaceLow = Closer to the moon now, you see that craters have ravaged the surface. Even the plains are unforgiven, which makes you infer that time has taken its toll on the Mun's surface... 
+				MunInSpaceHigh = The Mun appears to be very cratered while the lowlands sit pristinely below all of the mountains. 
+
+	MinmusSrfLandedLowlands = In pictures, the gently rolling lowlands almost appear to be the surface of roiling sea of melted mint ice cream.
+	MinmusSrfLandedHighlands = The highland regions of Minmus are difficult to separate from other regions in photos requiring altitude measurements to know when the transition occured.
+	MinmusSrfLandedSlopes = The highly irregular slopes of Minmus have often been observed in photos as appearing to be "scoops of ice cream" on the surface.
+	MinmusSrfLandedFlats = It's flat, punctuated by a sharp increase in altitude around the perimeter.  Images help to show just how nearly perfectly level this region really is.
+	MinmusSrfLandedGreatFlats = One of the largest flatland regions on the surface, in pictures the great flats appear to be a perfectly smooth frozen lake of green liquid.
+	MinmusSrfLandedGreaterFlats = The largest continuous flat region on the surface, the Greater Flats may once have been a sea of liquid on the surface that has long since frozen.  Images from this region reveal just how large it is as certain areas actually go to the horizon with no change in appearance.
+	MinmusSrfLandedLesserFlats = These smaller flat regions appear regularly around the moon and likely were small lakes at some point.  Photos taken in this region are surrounded on all sides by large hills forming the slopes and higher regions of Minmus.
+	MinmusSrfLandedPoles = Image data from the poles is helping to answer questions whether Minmus was once a comet that was captured by Kerbin or whether some alien race simply spilled their giant bowl of mint ice cream.  Researchers are inclined to believe the former but the general public is another question...
 	MinmusSrfLanded = The minty colored surface amazes you as you stare above and below where you have taken this photo. 
-	DunaInSpaceHigh = The pale orange dot resembles a ball or rust, or a red velvet cupcake...
-	DunaInSpaceLow = Duna has a vide variety of terrain, ranging from deep chasms, to tall mountain ranges, and plains. Its ice caps are large and dominant of the poles. 
-	DunaSrfLanded = The red dirt below you appears to be coarse and dry. Wait, did that rock move between photos?
-	IkeInSpaceHigh = The rock we call Ike is massive. It appears to be quite dense from so far away. It also appears to have very rugged terrain, more so than your own moon. 
-	IkeInSpaceLow = Ike shows its weathered terrain quite clearly. Mountain ranges dominate the surface while the plains come in dark, large patches. 
-	IkeSrfLanded = The pictures show rocky evidence of recent tectonic activity. 
-	DresInSpaceHigh = Dres reminds you of the Mun. It holds quite uneven terrain with a grey hue. 
-	DresInSpaceLow = Closer to Dres now, you begin to collect evidence that she is not a planet, but she is a dwarf planet which once was a gargantuan rogue asteroid. 
+		MinmusInSpaceLow = Minmus reveals varying terrain. High plateaus stretch for kilometres and the plains below them stretch even farther. 
+				MinmusInSpaceHigh = From so far away, Minmus resembles a small scoop of mint ice cream... 
+	
+	MohoSrfLandedHighlands = Surface photos in the highlands reveal Moho had to have been volcanically active at some point in the past.  Lava fields and other geologic formations of this region could only have been formed by such activity.
+	MohoSrfLandedMidlands = Photos taken within the midland region lend further support to the idea that much of Moho's surface has been shaped by volcanism.
+	MohoSrfLandedMinorCraters = These various small craters are numerous on the surface of Moho and photos within them are helping to answer some of the questions about it's geologically active periods.
+	MohoSrfLandedNorthPole = Unlike it's polar opposite, the north pole of Moho is extremely irregular and cratered with vastly different high and low points.  Photographic evidence clearly shows the highly varied surface.
+	MohoSrfLandedNorthernSinkhole = At one time, stories were rampant that an enormous hole existed in this region which penetrated deep into the planet.  Photographic evidence has shown this not to be true.  The public outcry of a government cover-up has reached epic proportions.
+	MohoSrfLandedNorthernSinkholeRidge = A long, narrow ridge spanning a good deal of this sinkhole region shows up starkly in photographs.  It is believed to be the product of volcanism but more study will be needed.
+	MohoSrfLandedCentralLowlands = The lowland regions of the planet are home to numerous small craters and dune like rock formations shown repeatedly in pictures of these regions.
+	MohoSrfLandedWesternLowlands = Similar to the other lowland regions of the planet, evidence of volcanism and repeated impacts show up regularly in image data.
+	MohoSrfLandedSouthWesternLowlands = The lowland regions in the west, just like the other lowland areas of the planet are home to clear geologic formations created by volcanism and photo evidence will help to fill in gaps in our knowledge of this world.
+	MohoSrfLandedSouthEasternLowlands = Further study of the various lowland regions in image data will all help to identify the causes of Moho's volcanic past and will help in the study of tidal erosion caused by the sun.
+	MohoSrfLandedCanyon = The deep canyons and sharp walls are further evidence of geologic activity on the planet as no liquid could have eroded this region.  Photo evidence helps to support the idea this region was created through volcanic activity.
+	MohoSrfLandedSouthPole = The south pole of Moho is similar in appearance and formation as the various lowlands.  Nearly uniform in altitude with very few craters or differences in high and low points, image data reveals this to be as different from the north pole in appearance as it is in location.
+	MohoSrfLanded = After your descent, you see the distinct features of the planet. Craters are visible as far as the eye can see. 
+		MohoInSpaceLow = Craters become clear on Moho's surface. With immense detail, the craters have craters. This reminds you that you are too close for comfort... 
+			MohoInSpaceHigh = Moho floats far away, punished with craters. You can almost see the heat of the home star, Kerbol... 
+
+	EveSrfLanded = The purple sand of this dense planet stretches across the surface. You get hungry and wonder if this sand is toxic if eaten... 
+	EveSrfLandedPoles = Image data from the surface shows just how uniform and regular the poles of Eve really are.  Slight variations in altitude are revealed but very little in the way of extensive surface features exist to break up the nearly flat regions.
+	EveSrfLandedExplodiumSea = A vast, low lying sea of liquid hydrocarbons shows vividly purple in image data.  It is quite obvious that the coloration caused by the hydrocarbons in both the sea and atmosphere lends Eve its distinct appearance.
+	EveSrfLandedLowlands = Very low altitudes and gentle, rolling landscapes make up most of the lowlands creating a very purple picturesque image.
+	EveSrfLandedMidlands = Similar to the lowlands, the midlands differ primarily in their altitude.  The same rolling landscape with very little in the way of features is captured clearly in image data.
+	EveSrfLandedHighlands = While areas leading to the peaks have broken and irregular landscapes, most of the highlands are revealed in photographs to be extremely similar to the other land regions of the planet.
+	EveSrfLandedPeaks = An amazing feature of Eve is the sharp, distinct peaks jutting thousands of meters above the surface with sheer cliffs and canyons nestled between them.  The image data from this area has proven to be the public's favorite for it's vistas and distinct appearance.
+	EveSrfLandedImpactEjecta = The narrow bands of impact ejecta are proving fascinating to scientists as they struggle to understand the image data which appears to show numerous regions around the planet where bodies have survived the atmosphere to impact the surface.
+		EveFlyingLow = With numerous low areas and vast, unbroken regions, image data collected in flight is proving most valuable to scientists.
+			EveFlyingHigh = With the few surface details obliterated due to altitude, photographic data from hgh altitudes is mostly useful to help refine mapping data for the planet.
+				EveInSpaceLow = Eve greets you with great delight as you swoop past, revealing how vast her Explodium Oceans are. You now want a grape popsicle... 
+					EveInSpaceHigh = Eve shimmers with its purple hue down below you. Or was it up? You can't remember... 
+
+
+
+	GillySrfLanded = The photo shows a wide variety of mountains. There is really nothing else here.	
+	GillySrfLandedLowlands = The highly irregular surface of this captured asteroid shows up distinctly in image data.  Even the lowlands aren't exactly low in most places and finding level ground is nearly impossible even when looking over photographs.
+	GillySrfLandedMidlands = The midlands, like the other regions of this barren rock, is as irregular as it is odd looking.  The beige color of the surface shows up in sharp cut relief against the walls of valleys and mountains.
+	GillySrfLandedHighlands = The highland regions are more erratic in shape, altitude and slope than any other region of this small body causing long shadows and prominent peaks to be cast in stark relief of the image data.
+		GillyInSpaceLow = Gilly, a beige captured asteroid reveals very extreme terrain. A blur in the photo shows its fast rotation. 
+			GillyInSpaceHigh = Gilly barely resembles a dot in the photo. 
+		
+	DunaSrfLanded = The red dirt below you appears to be coarse and dry. Wait, did that rock move between photos?	
+	DunaSrfLandedHighlands = Photographs show the rolling hills of the Duna highlands and the irregular surface indicating the presence of geologic activity in the far distant past.
+	DunaSrfLandedCraters = Impact craters on the surface of Duna are easily seen in imaging data due to the very low levels of erosion on the surface.
+	DunaSrfLandedPoles = The ice covered poles of Duna shine brightly in pictures and details of the broken glacier fields become readily apparent.
+	DunaSrfLandedLowlands = The lowlands, like many other areas on Duna, are varied in altitude and surface features.  Imaging data reveals the long term presence of liquid on the surface contributed to erosion in combination with geologic activity on the surface.
+	DunaSrfLandedMidlands = The midlands lack a defining boundary between regions making it difficult to determine where the highlands end, the midlands begin and the lowland take over.  Further evidence within the imaging data of past geological activity will leave researchers in a tizzy for several years you're sure.
+		DunaFlyingLow = Surface details showing erosion, weather activity and long term geologic activity is easily seen in photographs from low altitude.
+			DunaFlyingHigh = The details of the surface have faded but large scale features revealing long term changes to the surface is unmistakable in photos from high altitude.
+				DunaInSpaceLow = Duna has a vide variety of terrain, ranging from deep chasms, to tall mountain ranges, and plains. Its ice caps are large and dominant of the poles. 
+					DunaInSpaceHigh = The pale orange dot resembles a ball or rust, or a red velvet cupcake...
+	
+	IkeSrfLanded = The pictures show rocky evidence of recent tectonic activity.	
+	IkeSrfLandedPolarLowlands = The polar lowlands are one of the few fairly level regions of Ike's surface.  It is unknown whether this is formerly an impact crater or simply a surface feature and photos do not help to determine the answer to this nagging question.
+	IkeSrfLandedMidlands = Like the majority of the Ike, the midlands are a broken landscape marked by vastly different altitudes, steep slopes and cliffs and a distinct lack of craters all of which is revealed in imaging data.
+	IkeSrfLandedLowlands = The lowlands of Ike are deep depressions in the surface at much lower altitudes than most of the moon.  Imaging data shows the transition regions of these areas to be extremely steep and rising quickly to mountain ridges and the higher altitudes of the midlands.
+	IkeSrfLandedEasternMountainRidge = The tallest peak on the surface can be found along the Eastern Mountain Ridge and proves to be one of the best places to take wife field images of the surface.
+	IkeSrfLandedWesternMountainRidge = The Western Mountain Ridge, although lower in over all altitude, spans almost the entire surface of Ike from pole to pole and it's many plateuas would be very picturesque if it you could actually see anything.  Unfortunately, this region faces away from Duna at all times leaving it largely in darkness due to the low levels of sunlight.
+	IkeSrfLandedCentralMountainRange = The Central Mountain Range, on average, is even lower in altitude than the western ridge but it faces Duna at all times.  This creates opporunities for stunning views across the surface of Ike and out into space towards Duna which you take advantage of with your camera.
+	IkeSrfLandedSouthEasternMountainRange = Like the Western Mountain Ridge, the Easter Range is located on the side of Ike facing away from Duna leaving it in shadowy darkness most of the time.  Your images do littel to illuminate this area.
+	IkeSrfLandedSouthPole = The South Pole of Ike is a colossal plateau towering over 9000m in most places.  It also has a fairly level average surface slope making it an excellent place for landing and research.  However, due to Ike's axial tilt, it faces away from Duna and mostly lies in shadow except in the most westerly areas of the region making your image data difficult to interpret.
+		IkeInSpaceLow = Ike shows its weathered terrain quite clearly. Mountain ranges dominate the surface while the plains come in dark, large patches. 
+			IkeInSpaceHigh = The rock we call Ike is massive. It appears to be quite dense from so far away. It also appears to have very rugged terrain, more so than your own moon. 
+	
 	DresSrfLanded = The surface is barren with intermittent hills surrounding you. The flat areas you once saw, are not as flat as you thought. 
-	JoolInSpaceHigh = Jool's many moons are seen fantastically before her like a ballet of crumbs around that key lime cake you just devoured. 
-	JoolInSpaceLow = The green hue of Jool dominates the photo with great immensity. 
-	LaytheInSpaceHigh = From here, Laythe looks like a pale blue marble. 
-	LaytheInSpaceLow = Laythe has islands, water, and an atmosphere. You wouldn't be suprised if we found microkerbals here... 
+	DresSrfLandedPoles = The surface of Dres is well known for it's lack of cratering and the poles are no exception.  Photo evidence confirms this.
+	DresSrfLandedHighlands = The highlands of Dres are not exactly high in comparison to similar regions of the solar system so named.  They are small in area and are largely devoid of craters in photos.  Odd considering they are technically supposed to be the tallest and most exposed regions of the planet.
+	DresSrfLandedMidlands = Image data shows the midland regions of Dres to be an irregular, broken landscape showing no regular boundaries between regions and frequent changes in altitude.
+	DresSrfLandedLowlands = The lowland regions of Dres are vast and photo evidence shows that a majority of the few impact craters on the surface occur in these areas.
+	DresSrfLandedRidges = The ridges of Dres are not tall despite the name.  Pictures of these zones show them to be steeply sloped and higly irregular.
+	DresSrfLandedImpactEjecta = The impact regions of Dres are surrounded by tiny regions of ejecta blankets where debris from the collision spreds out from the impact site.  Photo evidence clearly shows how small these locales really are.
+	DresSrfLandedImpactCraters = Like other bodies lacking an atmosphere, Dres has impact craters although very few of them in comparion.  Your image data of suspected impact zones may help to identify others.
+	DresSrfLandedCanyons = The canyons of Dres have some of the steepest and tallest walls you have seen yet.  Photos of the region are difficult to analyze because these zones are in nearly constant shadow from the cliff sides.
+		DresInSpaceLow = Closer to Dres now, you begin to collect evidence that she is not a planet, but she is a dwarf planet which once was a gargantuan rogue asteroid. 
+			DresInSpaceHigh = Dres reminds you of the Mun. It holds quite uneven terrain with a grey hue. 
+	
+\\	JoolFlyingLow = 
+\\		JoolFlyingHigh = 
+			JoolInSpaceLow = The green hue of Jool dominates the photo with great immensity. 
+				JoolInSpaceHigh = Jool's many moons are seen fantastically before her like a ballet of crumbs around that key lime cake you just devoured. 
+	 	
+	
 	LaytheSrfLanded = The sandy beaches with dunes and pristine waters make you think of Kerbin. 
-	VallInSpaceHigh = Vall stands valiant, far away, as a pale blue dot. 
-	VallInSpaceLow = Vall holds blue plains and lighter blue mountains ranges that snake around the planet's surface in every which way. 
+\\	LaytheSrfLandedDunes =
+\\	LaytheSrfLandedShores =
+\\	LaytheSrfLandedPoles = 
+\\	LaytheSrfLandedCrescentBay = 
+\\	LaytheSrfLandedTheSaganSea = 
+\\		LaytheFlyingLow =
+\\			LaytheFlyingHigh =
+				LaytheInSpaceLow = Laythe has islands, water, and an atmosphere. You wouldn't be suprised if we found microkerbals here... 
+					LaytheInSpaceHigh = From here, Laythe looks like a pale blue marble. 
+
+	
 	VallSrfLanded = There are no even landing spots on this moon. Perhaps it is a consequence of cryo-volcanism or the tidal forces exerted on Vall. 
-	TyloInSpaceHigh = Tylo, from so far out, appears to be speckled. Why didn't we name it Spot? 
-	TyloInSpaceLow = Tylo is humongous. It is a massive rock the size of Kerbin. The speckles turn out to be tens of thousands of craters. Tylo reveals a highly beaten surface like the Mun. The scientists in the lab infer that Tylo does indeed have trace amounts of cobalt. 
+\\	VallSrfLandedPoles = 
+\\	VallSrfLandedMidlands =
+\\	VallSrfLandedlowlands =
+\\	VallSrfLandedHighlands =
+			VallInSpaceLow = Vall holds blue plains and lighter blue mountains ranges that snake around the planet's surface in every which way. 
+				VallInSpaceHigh = Vall stands valiant, far away, as a pale blue dot. 
+	
 	TyloSrfLanded = Tylo holds a very dusty surface. The craters seen from above appear to be just another surface feature now. 
-	BopInSpaceHigh = Bop seems to be a brown captured asteroid not unlike Gilly. Perhaps they are related?
-	BopInSpaceLow = Bop appears to reveal a crater with a white rim, which perhaps, could be evidence of a young captured Bop in a young Joolian system. 
+\\	TyloSrfLandedMajorCrater =
+\\	TyloSrfLandedMajorCrater =
+\\	TyloSrfLandedMajorCrater =
+\\	TyloSrfLandedMinorCraters =
+\\	TyloSrfLandedHighlands = 
+\\	TyloSrfLandedMidlands = 
+\\	TyloSrfLandedLowlands = 
+\\	TyloSrfLandedMara = 
+		TyloInSpaceLow = Tylo is humongous. It is a massive rock the size of Kerbin. The speckles turn out to be tens of thousands of craters. Tylo reveals a highly beaten surface like the Mun. The scientists in the lab infer that Tylo does indeed have trace amounts of cobalt. 
+			TyloInSpaceHigh = Tylo, from so far out, appears to be speckled. Why didn't we name it Spot? 
+
+	
 	BopSrfLanded = Bop gives off a peculiar vibe. It is very dark and desolate. Was it once a comet? 
-	PolInSpaceHigh = Pol, the speck across the way, reminds you of a pollen grain. 
-	PolInSpaceLow = Pol seems unforgiving. Like her sister Bop, she seems to be a captured asteroid. The rough, jagged, and derranged terrain make you think twice about landing. 
+\\	BopSrfLandedPoles = 
+\\	BopSrfLandedSlopes = 
+\\	BopSrfLandedMara = 
+\\	BopSrfLandedRidges = 
+\\	BopSrfLandedValley =
+\\	BopSrfLandedPeaks =
+		BopInSpaceLow = Bop appears to reveal a crater with a white rim, which perhaps, could be evidence of a young captured Bop in a young Joolian system. 
+			BopInSpaceHigh = Bop seems to be a brown captured asteroid not unlike Gilly. Perhaps they are related?
+	
 	PolSrfLanded = Apparently, you landed. The yellow and khaki colored surface seems nice. Oh wait, are you sliding down the cliff?? 
-	EelooInSpaceHigh = Eeloo appears to be very icy. It's spent too long this far away from Kerbol.  
-	EelooInSpaceLow = Eeloo shows its true self as you approach, revealing her ice canyons and chasms. 
+\\	PolSrfLandedPoles =
+\\	PolSrfLandedLowlands = 
+\\	PolSrfLandedMidlands =
+\\	PolSrfLandedHighlands = 
+		PolInSpaceLow = Pol seems unforgiving. Like her sister Bop, she seems to be a captured asteroid. The rough, jagged, and derranged terrain make you think twice about landing. 
+			PolInSpaceHigh = Pol, the speck across the way, reminds you of a pollen grain. 
+
+	
 	EelooSrfLanded = Eeloo appears to show evidence of a once thin atmosphere. Possibly there are hidden cryo-volcanos that spray gases into the vaccum, intermittently causing a temporary atmosphere. 
+\\	EelooSrfLandedPoles = 
+\\	EelooSrfLandedGlaciers =
+\\	EelooSrfLandedMidlands = 
+\\	EelooSrfLandedLowlands = 
+\\	EelooSrfLandedIceCanyons =
+\\	EelooSrfLandedHighlands = 
+\\	EelooSrfLandedCraters = 
+		EelooInSpaceLow = Eeloo shows its true self as you approach, revealing her ice canyons and chasms. 
+			EelooInSpaceHigh = Eeloo appears to be very icy. It's spent too long this far away from Kerbol.  
 	}
 }
 
@@ -383,6 +558,85 @@ EXPERIMENT_DEFINITION
 	RESULTS
 	{
 	default = You measure the amount of moisture in the planet's atmosphere.
+
+	KerbinSrfLandedAdministration = Readings reveal high volumes of ethanol in the air.  Perhaps the administrators should cut back on lunch visits to the bar...
+	KerbinSrfLandedAstronautComplex = The High-G centrifuge is located in this building and readings show significant levels of gastric acids nearby.
+	KerbinSrfLandedCrawlerway = The toxicity levels from evaporating rocket fuel shows up in analysis of the data from here.
+	KerbinSrfLandedFlagPole = The flag pole has some dew on it...WHAT AN AMAZING DISCOVERY!!!
+	KerbinSrfLandedLaunchPad = Toxicity levels from evaporating fuel has increased by an order of magnitude compared to the crawlerway.  Are you wearing a biohazard suit?
+	KerbinSrfLandedMissionControl = You really shouldn't be detecting any alcohol in the air near this facility but...
+	KerbinSrfLandedR&D = The amount of hot air emanating from the mouths of the researchers here has evaporated most of the moisture in the area.
+	KerbinSrfLandedR&DCentralBuilding = You know, all you did was go around the corner.  The moisture readings have not changed.
+	KerbinSrfLandedR&DCornerLab = So you went back to the other side and thought moisture levels would be different.  They're not...
+	KerbinSrfLandedR&DMainBuilding = How many times do you have to be told, moisture levels don't change very much over 100 feet of distance.
+	KerbinSrfLandedR&DObservatory = De-humidifiers help keep the observatory area at lower levels of moisture.  Well inside the building they do anyway...
+	KerbinSrfLandedR&DSideLab = If you keep taking readings so close together you're going to get confused about where they came from since they're still the same.
+	KerbinSrfLandedR&DSmallLab = Apparently the bathroom inside the small lab was occupied.  You detect high concentrations of...well...stuff you weren't expecting.
+	KerbinSrfLandedR&DTanks = If you had a spectrometer you might be able tell what was inside these tanks but the moisture levels tell you nothing.
+	KerbinSrfLandedR&DWindTunnel = There's a nice breeze here.  It's a pleasant day outside too.  Really would be lovely to visit the beach.  Oh, you're supposed to be taking readings but since they keep coming out the same you started daydreaming.
+	KerbinSrfLandedRunway = Jet fuel spills in this area have made accurate moisture readings impossible here.
+	KerbinSrfLandedSPH = After being chased from the R&D area by and angry researcher you thought you might get different readins by the hangar.  Nope.
+	KerbinSrfLandedSPHMainBuilding = Weren't you told recently that readings don't really change over short distances?  If not, you're being told now.
+	KerbinSrfLandedSPHRoundTank = You'd guess there is jet fuel in the tanks but the hydrometer doesn't tell you anything other than it appears to be leaking.
+	KerbinSrfLandedSPHTanks = As with the round tank, there appears to be a jet fuel leak in the area since moisture readings are higher.  If you light a match you could confirm the spill...
+	KerbinSrfLandedSPHWaterTower = This is a water tower.  There's so much water here you might as well be taking readings on the ocean.
+	KerbinSrfLandedTrackingStation = The engineer at the SPH said you'd have better luck over here but the readings haven't changed.
+	KerbinSrfLandedTrackingStationDishEast = You're stubbornly trying to find different readings of moisture levels in this area aren't you?
+	KerbinSrfLandedTrackingStationDishNorth = HEY LOOK!  The readings are exactly the same as by the North Dish!  That's amazing!
+	KerbinSrfLandedTrackingStationDishSouth = If you haven't been able to tell yet, the hydrometer is startng to get an attitude about giving the exact same readings to you over an over again.
+	KerbinSrfLandedTrackingStationHub = You know, Kalbert Keinstein said insanity is doing the same thing over and over again and getting the same results.  Have you had your monthly psychological examination yet?
+	KerbinSrfLandedVAB = Well the VAB is just as mosit as the SPH and R&D buildings and the Astronaut Complex and the Administration building and the runway and crawlerway and launch pad.  Are you seeing a pattern yet?
+	KerbinSrfLandedVABMainBuilding = Perhaps you should go take readins by the tracking station hub in order to see how futile this measurement really is.
+	KerbinSrfLandedVABPodMemorial = YES!  THE READINGS ARE DIFFERENT HERE!  You measure a change in moisture levels of .000000001 percent.
+	KerbinSrfLandedVABRoundTank = If you keep playing with it you're going to break it.  Nothing about the readings have changed.
+	KerbinSrfLandedVABSouthComplex = Perhaps it wasn't made clear from any other result but NOTHING HAS CHANGED!!!!
+	KerbinSrfLandedVABTanks = The instrument finally gives up.  A snap, crackle and pop sound emit from the electronics and a small wisp of smoke emanates from the hydrometer as it gives you one last reading that shows absolutely nothing has changed in the moisture levels at the KSC.
+	KerbinSrfLandedKSC = As the KSC sits on the coast near an ocean moisture readings are very high.
+	
+	KerbinSrfLanded = Readings indicate that there is moisture in the air in levels commiserate with the humidity of the region.
+	KerbinSrfLandedGrasslands = Readings from here have revealed the presence of moisture in significant quantities.
+	KerbinSrfLandedTundra = Cold temperatures have decreased the levels of moisture in the atmosphere significantly.
+	KerbinSrfLandedMountains = As altitude increases, moisture levels are droping.
+	KerbinSrfLandedBadlands = The near desert conditions of the badlands causes a very low moisture reading.
+	KerbinSrfLandedDeserts = It's the desert.  What did you expect?  A monsoon?
+	KerbinSrfLandedHighlands = Higher altitudes and lower temperatures creates an environment with lower moisture readings.
+	KerbinSrfLandedIceCaps = The sub-zero temperatures of the poles has frozen the majority of moisture out of the air leading to desert like readings.
+	KerbinSrfLandedShores = If you were to look up from the computer you'd realize there was a large body of water in front of you.  Moisture readings are elevated.
+	KerbinSrfLandedWater = The scanner readouts reveal that you are IN THE WATER!!!!!!!!!
+		KerbinFlyingLow = Comparision of the humidity data in flight to the moisture readings shows a direct correlation between the measurements of moisture and the measurements of moisture.
+			KerbinFlyingHigh = Above 18km moisture readings drop of precipitously as the temperatures decrease rapidly the higher you go indicating that moisture is freezing out of the air.
+
+	EveSrfLanded = You've never see readings quite like these revealing the presence of significant levels of hydrocarbons in the air.
+	EveSrfLandedPoles = The lower temperatures at the poles has created conditions favorable to the formation of hydrocabons in liquid form on the surface and in the air.
+	EveSrfLandedExplodiumSea = Ok, it may not be a sea like you would think of pleasantly back home but IT IS STILL A BIG BODY OF LIQUID!  Of course readings are high...
+	EveSrfLandedLowlands = The higher pressure of this area has caused puddles of hydrocarbons to form on the surface.  Lighting a match might be a bad idea...
+	EveSrfLandedMidlands = As with water in the atmosphere back home, the levels of hydrocarbons in the air appears to drop off with increases in altidude.
+	EveSrfLandedHighlands = Readings from this area confirm that higher altitudes and lower moisture readins have a direct correlation.
+	EveSrfLandedPeaks = Another piece of the moisture puzzle fits together with readings from lower altitudes indicating decreases in moisture with higher altidudes.
+	EveSrfLandedImpactEjecta = The sub-surface chemical composition is partially revealed with moisture readings from this area.
+		EveFlyingLow = Readings in flight show the atmosphere could potentially be harvested for hydrocarbons.
+			EveFlyingHigh = Lower levels of moisture are found at higher altitudes, yet the fantastic atmospheric pressure on this planet still allows detectable levels of liquid hydrocarbons.
+			
+	DunaSrfLanded = Low temperatures and a very thing atmosphere lead to extremely dry conditions around the planet.
+	DunaSrfLandedHighlands = The higher altitudes of the highlands creates a nearly moisture free environment.
+	DunaSrfLandedCraters = Even this close to the surface, atmospheric moisture readings are extremely low.
+	DunaSrfLandedPoles = Water and frozen CO2 are present on the surface and sublimation causes this area to have far higher moisture readings than the rest of the planet.
+	DunaSrfLandedLowlands = Levels in the soil are low but detectable however the atmospheric readings still show a marked lack of moisture.
+	DunaSrfLandedMidlands = AN AMAZING DISCOVERY!!!  High levels of moisture have been found...oh.  Nevermind, someone evacuated the waste disposal tank...
+		DunaFlyingLow = Moisture levels are so low as to be nearly undetectable due to the low pressure and temperatures around the planet.
+			DunaFlyingHigh = Practically no moisture exists in the upper atmosphere as the pressure and temperatures prevent liquid from forming in the air.
+			
+	JoolFlyingLow = The stupendous pressure at these levels has made the atmosphere nearly soup like.  It would be more appropriate to say you were swimming than flying.
+	JoolFlyingHigh = Even at the edge of the atmosphere, moisture levels are extremely high although it primarily consists of ammonia based compounds.
+	
+	LaytheSrfLanded = Almost the entire surface of the moon is covered in liquid water.  What kind of readings did you expect?  Dry?
+	LaytheSrfLandedDunes = Although this area is desert like in appearance the moisture levels are through the roof thanks to the nearly ubiquitous presence of liquid water on the surface.
+	LaytheSrfLandedShores = As with standing on the shores at home, if you look up, there's a giant body of water in front of you so moisture readings are low of course...NOT!
+	LaytheSrfLandedPoles = Even at the poles water remains in liquid form and in high concentrations in the atmosphere lending support to the theory that high levels of salt are also present in the water.  Spectroscopic readings might be able to prove this theory conclusively.
+	LaytheSrfLandedCrescentBay = It's still a giant body of water.  Did you think it was going to be dry?
+	LaytheSrfLandedTheSaganSea = Sailing, sailing over The Sagan Sea, for many a rocket shall exlode ere Kerbin we will see!
+		LaytheFlyingLow = At low altitudes the moisture readings are nearly the same as the surface but begin to drop off as altitude increases.
+			LaytheFlyingHigh = As with other atmospheric bodies, moisture levels at high altidude drop off abruptly.
 	}
 }
 


### PR DESCRIPTION
Here's the same list I'm PM'ing you with in the forums just in case you miss either one.

Changes

CTT patch updated for most recent parts.  Small balance pass on some parts from previous iteration.
Updated AR patch for both stock and OPM.  Antenna transmission speeds have had a balance pass and the A66 got hit by a giant nerf bat.
A27-C Dish antenna has been added to both AR patches.
Added complete science definitions for the Hydrometer for all stock planets and all situations the experiment can be run.
Added camera science definitions for all 'SrfLandedXXXXX' biomes from Moho to Dres.  Jool system and Eeloo remains for stock solar system.
Balance pass for all three cameras.
	- The low tech camera remains unchanged.
	- The mid-tech camera has been changed to allow up to 6 images to be taken.  All other stats remain unchanged
	- The high-tech camera has been changed significantly.  It now allows unlimited images, mass has been reduced to .025 and the tech node has been moved up to Advanced Science Tech.