### PR TITLE
Update tweakscale_Apollo.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Tweakscale/tweakscale_Apollo.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Tweakscale/tweakscale_Apollo.cfg
@@ -35,7 +35,7 @@
 	}
 }
 
-@PART[bluedog_Apollo_Block2_Heatshield] // Kane-11-MSHS 2.5m Heat Shield
+@PART[bluedog_Apollo_Block2_Heatshield]:NEEDS[TweakScale] // Kane-11-MSHS 2.5m Heat Shield
 {
 	%MODULE[TweakScale]
 	{
@@ -71,7 +71,7 @@
 	}
 }
 
-@PART[bluedog_Apollo_Block2_RCSquad] // Kane-DTS RCS Thruster Quad
+@PART[bluedog_Apollo_Block2_RCSquad]:NEEDS[TweakScale] // Kane-DTS RCS Thruster Quad
 {
 	#@TWEAKSCALEBEHAVIOR[Engine]/MODULE[TweakScale] { }
 	%MODULE[TweakScale]
@@ -80,7 +80,7 @@
 	}
 }
 
-@PART[bluedog_Apollo_Block2_ServiceEngine] // Kane-11-SE65 Service Propulsion System
+@PART[bluedog_Apollo_Block2_ServiceEngine]:NEEDS[TweakScale] // Kane-11-SE65 Service Propulsion System
 {
 	#@TWEAKSCALEBEHAVIOR[Engine]/MODULE[TweakScale] { }
 	%MODULE[TweakScale]
@@ -90,7 +90,7 @@
 	}
 }
 
-@PART[bluedog_Apollo_Block2_ServiceModule] // Kane-11-MSM Service Module
+@PART[bluedog_Apollo_Block2_ServiceModule]:NEEDS[TweakScale] // Kane-11-MSM Service Module
 {
 	%MODULE[TweakScale]
 	{


### PR DESCRIPTION
Was missing a few :NEEDS[TweakScale] that were showing as Module Manager errors in non-tweakscale game load