### PR TITLE
Update tweakscale_Apollo.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Tweakscale/tweakscale_Apollo.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Tweakscale/tweakscale_Apollo.cfg
@@ -9,7 +9,7 @@
 
 //@PART[bluedog_Apollo_Block2_Capsule]:NEEDS[TweakScale] // Kane-11-3 Command Pod
 
-@PART[bluedog_Apollo_Block2_Decoupler] // Kane 2.5m Capsule Decoupler
+@PART[bluedog_Apollo_Block2_Decoupler]:NEEDS[TweakScale] // Kane 2.5m Capsule Decoupler
 {
 	#@TWEAKSCALEBEHAVIOR[Decoupler]/MODULE[TweakScale] { }
 	%MODULE[TweakScale]


### PR DESCRIPTION
Found last issue causing Module Manager error in non-tweakscale loading

:NEEDS[TweakScale] was missing from @PART[bluedog_Apollo_Block2_Decoupler]