### PR TITLE
Fix Typo'd resource node in centaurShortTank

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Centaur/bluedog_centaurShortTank.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Centaur/bluedog_centaurShortTank.cfg
@@ -40,7 +40,7 @@ MODEL
 		amount = 180
 		maxAmount = 180
 	}
-	\RESOURCE
+	RESOURCE
 	{
 		name = Oxidizer
 		amount = 220


### PR DESCRIPTION
Apparently this got whacked on accident in commit a589e7a