### PR TITLE
Tentative RCS MM patch for 1.2

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/1_2patches/12_BDB-RCS.txt
+++ b/Gamedata/Bluedog_DB/Compatibility/1_2patches/12_BDB-RCS.txt
@@ -1,0 +1,41 @@
+RT[bluedog*,Bluedog*]:HAS[@MODULE[ModuleRCS]
+{
+    EFFECTS
+    {
+        running
+        {
+            AUDIO_MULTI
+            {
+                channel = Ship
+                transformName = #$MODULE[ModuleRCS]/thrusterTransformName$
+                clip = sound_rocket_mini
+                volume = 0.0 0.0
+                volume = 0.1 0.0
+                volume = 0.5 0.025
+                volume = 1.0 0.1
+                pitch = 0.0 0.75
+                pitch = 1.0 1.5
+                loop = true
+            }
+            MODEL_MULTI_PARTICLE
+            {
+                modelName = Squad/FX/Monoprop_small
+                transformName = #$MODULE[ModuleRCS]/thrusterTransformName$
+                emission = 0.0 0.0
+                emission = 0.1 0.0
+                emission = 1.0 1.0
+                speed = 0.0 0.8
+                speed = 1.0 1.0
+                localRotation = -90, 0, 0
+            }
+        }
+    }
+
+    @MODULE[ModuleRCS]
+    {
+        @name = ModuleRCSFX
+        %stagingEnabled = False
+        %resourceFlowMode = STAGE_PRIORITY_FLOW
+        %runningEffectName = running
+    }
+}

--- a/Gamedata/Bluedog_DB/Compatibility/1_2patches/12_BDB-RCS.txt
+++ b/Gamedata/Bluedog_DB/Compatibility/1_2patches/12_BDB-RCS.txt
@@ -1,4 +1,4 @@
-@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleRCS]
+@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleRCS]]
 {
     EFFECTS
     {

--- a/Gamedata/Bluedog_DB/Compatibility/1_2patches/12_BDB-RCS.txt
+++ b/Gamedata/Bluedog_DB/Compatibility/1_2patches/12_BDB-RCS.txt
@@ -1,4 +1,4 @@
-RT[bluedog*,Bluedog*]:HAS[@MODULE[ModuleRCS]
+@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleRCS]
 {
     EFFECTS
     {


### PR DESCRIPTION
This is mainly a @jsolson patch. It's deliberately .txt as I have no idea if it will work as there is no 1.2 MM as of yet. Staring at the new stock RCS parts/modules, I think this will work. There exists a vague danger of an EFFECTS collision, but the agena engines didn't seem to have EFFECTS anyway.

Thoughts?