### PR TITLE
Apollo Service Module fails to load, part catagory

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_ServiceModule.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_ServiceModule.cfg
@@ -15,7 +15,7 @@ MODEL
 	TechRequired = commandModules
 	entryCost = 8000
 	cost = 4000
-	category = FuelTanks
+	category = FuelTank
 	subcategory = 0
 	title = Kane-11-MSM Service Module
 	manufacturer = Bluedog Design Bureau


### PR DESCRIPTION
This is a simple mistake; I have some other changes on my local branch, but this one stops the part from loading. Recommend merge ASAP to quell the support requests.