### PR TITLE
Replaced mentions of LFO in cryo tank/engine descriptions/tags with LHO

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Centaur/bluedog_Centaur_RL10.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Centaur/bluedog_Centaur_RL10.cfg
@@ -39,7 +39,7 @@ MODEL
 	maxTemp = 2000 // = 3600
 	bulkheadProfiles = size1
 	
-	tags = centaur inon saturn sarnus engine hydrolox cryogenic 
+	tags = centaur inon saturn sarnus engine lho oxidizer liquid hydrogen hydrolox cryogenic 
 	
 	MODULE
 	{

--- a/Gamedata/Bluedog_DB/Parts/Centaur/bluedog_Centaur_Tank.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Centaur/bluedog_Centaur_Tank.cfg
@@ -18,7 +18,7 @@ MODEL
 	subcategory = 0
 	title = Inon-D-1300 Fuel Tank
 	manufacturer = Bluedog Design Bureau
-	description = 1.875m tank for the Inon-D upper stage.
+	description = 1.875m LHO tank for the Inon-D upper stage.
 	attachRules = 1,1,1,1,0
 	mass = 0.325 //0.8125
 	dragModelType = default
@@ -31,7 +31,7 @@ MODEL
 	breakingTorque = 50
 	bulkheadProfiles = size1p5, srf
 	
-	tags = centaur inon lfo fuel tank 1.875 1875
+	tags = centaur inon lho oxidizer liquid hydrogen fuel tank 1.875 1875
 	
 //	RESOURCE
 //	{

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_J2.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_J2.cfg
@@ -40,7 +40,7 @@ subcategory = 0
 title = Sarnus-HE2J-550 "Dnoces" Liquid Engine
 manufacturer = Bluedog Design Bureau
 description = After Inon-derived upper stages proved too weak for large launchers, a new high-powered, high efficiency vacuum engine was created. While it sacrifices a bit of efficiency, the thrust to weight ratio is better for lifting upper stages. 
-tags = J2 Saturn Sarnus engine liquid fuel oxidizer lfo hydrolox hydrogen cryogenic 
+tags = J2 Saturn Sarnus engine fuel oxidizer lho hydrolox liquid hydrogen cryogenic 
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,1

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S2_Tankage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S2_Tankage.cfg
@@ -30,7 +30,7 @@ subcategory = 0
 title = Sarnus-SII-47K Liquid Fuel Tank
 manufacturer = Bluedog Design Bureau
 description = Massive 5.625m fuel tank for the S-II stage. 
-tags = 5.625m Saturn Sarnus hydrolox hydrogen fuel tank lfo liquid fuel oxidizer huge
+tags = 5.625m Saturn Sarnus hydrolox hydrogen fuel tank lho liquid fuel oxidizer huge
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S4B_Tankage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S4B_Tankage.cfg
@@ -26,8 +26,8 @@ category = Propulsion
 subcategory = 0
 title = Sarnus-SIVB-10K Liquid Fuel Tank
 manufacturer = Bluedog Design Bureau
-description = Medium sized 3.75m liquid fuel tank for upper stages.  
-tags = Saturn Sarnus 3.75m LFO liquid fuel oxidizer hydrolox hydrogen cryo tank
+description = Medium sized 3.75m liquid hydrogen tank for upper stages.  
+tags = Saturn Sarnus 3.75m lho fuel oxidizer hydrolox liquid hydrogen cryo tank
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S4_AdapterTank.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S4_AdapterTank.cfg
@@ -19,7 +19,7 @@ MODEL
 	subcategory = 0
 	title = Sarnus-SIV-2200 Liquid Fuel Tank
 	manufacturer = Bluedog Design Bureau
-	description = 3.125m to 2.5m LFO adapter tank for the Sarnus-SIV second stage.
+	description = 3.125m to 2.5m LHO adapter tank for the Sarnus-SIV second stage.
 	attachRules = 1,1,1,1,0
 	mass = 0.55 // 1.375
 	dragModelType = default
@@ -32,7 +32,7 @@ MODEL
 	maxTemp = 2000 // = 2900
 	bulkheadProfiles = size2, size2p5
 	
-	tags = saturn sarnus s1 first stage fuel tank large big
+	tags = saturn sarnus s1 first stage fuel tank large big lho oxidizer liquid hydrogen
 	
 //	RESOURCE
 //	{

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S4_Tankage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S4_Tankage.cfg
@@ -19,7 +19,7 @@ MODEL
 	subcategory = 0
 	title = Sarnus-SIV-3200 Liquid Fuel Tank
 	manufacturer = Bluedog Design Bureau
-	description = LFO tank for the Sarnus-SIV second stage. Disable the shroud to get rid of the fuel tank connectors if you're using it for a non-standard purpose.
+	description = LHO tank for the Sarnus-SIV second stage. Disable the shroud to get rid of the fuel tank connectors if you're using it for a non-standard purpose.
 	attachRules = 1,1,1,1,0
 	mass = 0.8// 2.0
 	dragModelType = default
@@ -32,7 +32,7 @@ MODEL
 	maxTemp = 2000 // = 2900
 	bulkheadProfiles = size2p5
 	
-	tags = saturn sarnus s4 first stage fuel tank large big
+	tags = saturn sarnus s4 first stage fuel tank large big lho oxidizer liquid hydrogen
 	
 //	RESOURCE
 //	{


### PR DESCRIPTION
Should I leave liquid in the tags? They have liquid hydrogen, but they still show up on searches for liquid fuel.