### PR TITLE
Adding missing monoprop and liquid hydrogen to Umbilical Tower generator.

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/LaunchClamps/FASA_Launch_Tower/FASA_Umbilical_Tower.cfg
+++ b/Gamedata/Bluedog_DB/Parts/LaunchClamps/FASA_Launch_Tower/FASA_Umbilical_Tower.cfg
@@ -31,7 +31,7 @@ category = Structural
 subcategory = 0
 title = FASA Umbilical Tower
 manufacturer = FASA
-description = This umbilical tower functions as a launch clamp and fuel pump for liquid fuel, oxidizer and mono-propellent. It also Provides electricity. Right click on the tower to start the fuel flow.
+description = This umbilical tower functions as a launch clamp and fuel pump for liquid fuel/hydrogen, oxidizer and mono-propellent. It also Provides electricity. Right click on the tower to start the fuel flow.
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 
@@ -84,6 +84,16 @@ OUTPUT_RESOURCE
 	{
 		name = Oxidizer
 		rate = 11
+	}
+OUTPUT_RESOURCE
+	{
+		name = MonoPropellant
+		rate = 5
+	}
+OUTPUT_RESORUCE
+	{
+		name = LqdHydrogen
+		rate = 165 // 11 * 15
 	}
 OUTPUT_RESOURCE
 	{


### PR DESCRIPTION
This one is pretty simple. The claimed monoprop generator was missing, and a liquid hydrogen one was added as well. I guessed on the monoprop ratio, but it should be ok.

Fun to see these guys again, i'd missed them.