### PR TITLE
Normalization of max temp on docking ports like stock ones 

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/APAS/CXA_APAS_A_L04F.cfg
+++ b/Gamedata/Bluedog_DB/Parts/APAS/CXA_APAS_A_L04F.cfg
@@ -40,7 +40,7 @@ angularDrag = 0.75
 crashTolerance = 15
 breakingForce = 200
 breakingTorque = 200
-maxTemp = 2600 //=3400
+maxTemp = 2000 //=3400
 fuelCrossFeed = True
 tags = ISS CxA APAS docking PMA tantares loaf bread
 

--- a/Gamedata/Bluedog_DB/Parts/APAS/CXA_APAS_P.cfg
+++ b/Gamedata/Bluedog_DB/Parts/APAS/CXA_APAS_P.cfg
@@ -40,7 +40,7 @@ angularDrag = 0.75
 crashTolerance = 15
 breakingForce = 200
 breakingTorque = 200
-maxTemp = 2400// =3400
+maxTemp = 2000// =3400
 fuelCrossFeed = True
 tags = ISS CxA APAS docking PMA
 

--- a/Gamedata/Bluedog_DB/Parts/Agena/bluedog_agenaPort.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Agena/bluedog_agenaPort.cfg
@@ -35,7 +35,7 @@ MODEL
 	crashTolerance = 8
 	breakingForce = 50
 	breakingTorque = 50
-	maxTemp = 1000
+	maxTemp = 2000
 	fuelCrossFeed = false
 //	stagingIcon = DECOUPLER_VERT // Removed. The icon always displays when the ModuleJettison is present
 	bulkheadProfiles = size0p5, srf

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_ActiveDockingMechanism.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_ActiveDockingMechanism.cfg
@@ -30,7 +30,7 @@ MODEL
 	crashTolerance = 8
 	breakingForce = 50
 	breakingTorque = 50
-	maxTemp = 1000
+	maxTemp = 2000
 	fuelCrossFeed = false
 	stagingIcon = DECOUPLER_VERT
 	bulkheadProfiles = size0

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_PassiveDockingMechanism.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_PassiveDockingMechanism.cfg
@@ -30,7 +30,7 @@ MODEL
 	crashTolerance = 8
 	breakingForce = 50
 	breakingTorque = 50
-	maxTemp = 1000
+	maxTemp = 2000
 	fuelCrossFeed = false
 	stagingIcon = DECOUPLER_VERT
 	bulkheadProfiles = size0


### PR DESCRIPTION
Modified to stock maxtemp at 2000:
- Apollo's APAS
- Apollo's active-passive
- after a quick check, the Agena's one too (the passive one that lock in the Gemini nose)
... all of them could eventually end as "nose port" of a rocket during ascent (maybe in non conventional use of them)