### PR TITLE
Fuel Switching adjustments. Don't merge blindly, test first.

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/CryoEngines/B9PartSwitchTanks.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/CryoEngines/B9PartSwitchTanks.cfg
@@ -2,7 +2,7 @@
 // Thanks Nertea
 //
 
-@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!@RESOURCE[MonoPropellant],!MODULE[ModuleEngines*]]:NEEDS[B9PartSwitch]:FOR[Bluedog_DB_0]
+@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleEngines*],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch]:FOR[Bluedog_DB_1]
 {
 	%tank_volume = #$RESOURCE[LiquidFuel]/maxAmount$
 	@tank_volume += #$RESOURCE[Oxidizer]/maxAmount$
@@ -44,7 +44,7 @@
 	}
 }
 
-@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LqdHydrogen],@RESOURCE[Oxidizer],!@RESOURCE[MonoPropellant],!MODULE[ModuleEngines*]]:NEEDS[B9PartSwitch]:FOR[Bluedog_DB_0]
+@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LqdHydrogen],@RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleEngines*],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch]:FOR[Bluedog_DB_1]
 {
 	%tank_volume = #$RESOURCE[LqdHydrogen]/maxAmount$
 	@tank_volume /= 5
@@ -87,7 +87,7 @@
 	}
 }
 
-@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LqdHydrogen]]:FOR[Bluedog_DB_1]
+@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LqdHydrogen]]:FOR[Bluedog_DB_8]
 {
 	MODULE
 	{
@@ -100,7 +100,20 @@
 	}
 }
 
-@PART[bluedog*,Bluedog*]:HAS[MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch]:FOR[Bluedog_DB_1]
+@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleB9PartSwitch]]:FOR[Bluedog_DB_8]
+{
+	MODULE
+	{
+		name = ModuleBdbBoiloff
+		CRYOGENICRESOURCE
+		{
+			name = LqdHydrogen
+			boiloffRate = 8
+		}
+	}
+}
+
+@PART[bluedog*,Bluedog*]:HAS[@MODULE[WBIResourceSwitcher]]:FOR[Bluedog_DB_8]
 {
 	MODULE
 	{

--- a/Gamedata/Bluedog_DB/Compatibility/CryoEngines/B9PartSwitchTanks.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/CryoEngines/B9PartSwitchTanks.cfg
@@ -25,7 +25,7 @@
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
-		switcherDescription = Tank Type
+		switcherDescription = Fuel
 		baseVolume = #$../tank_volume$
 		SUBTYPE
 		{
@@ -36,7 +36,7 @@
 		}
 		SUBTYPE
 		{
-			name = LH2/O (Std.)
+			name = LH2/O
 			tankType = LH2OStd
 			addedMass = #$../../tank_mass$
 			addedCost = #$../../tank_cost$
@@ -68,11 +68,11 @@
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
-		switcherDescription = Tank Type
+		switcherDescription = Fuel
 		baseVolume = #$../tank_volume$
 		SUBTYPE
 		{
-			name = LH2/O (Std.)
+			name = LH2/O
 			tankType = LH2OStd
 			addedMass = #$../../tank_mass$
 			addedCost = #$../../tank_cost$
@@ -100,7 +100,7 @@
 	}
 }
 
-@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleB9PartSwitch]]:FOR[Bluedog_DB_8]
+@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleB9PartSwitch],!MODULE[ModuleBdbBoiloff]]:FOR[Bluedog_DB_8]
 {
 	MODULE
 	{
@@ -113,7 +113,7 @@
 	}
 }
 
-@PART[bluedog*,Bluedog*]:HAS[@MODULE[WBIResourceSwitcher]]:FOR[Bluedog_DB_8]
+@PART[bluedog*,Bluedog*]:HAS[@MODULE[WBIResourceSwitcher],!MODULE[ModuleBdbBoiloff]]:FOR[Bluedog_DB_8]
 {
 	MODULE
 	{

--- a/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
@@ -10,15 +10,15 @@ WBI_BDB_FUEL_TEMPLATE
 	RESOURCE
 	{
 		 name = LiquidFuel
-		 amount = 810
-		 maxAmount = 810
+		 amount = 0.45
+		 maxAmount = 0.45
 	}
 
 	RESOURCE
 	{
 		name = Oxidizer
-		amount = 990
-		maxAmount = 990
+		amount = 0.55
+		maxAmount = 0.55
 	}
 
 }
@@ -35,15 +35,15 @@ WBI_BDB_FUEL_TEMPLATE
 	RESOURCE
 	{
 		 name = LqdHydrogen
-		 amount = 6750
-		 maxAmount = 6750
+		 amount = 3.75
+		 maxAmount = 3.75
 	}
 
 	RESOURCE
 	{
 		name = Oxidizer
-		amount = 450
-		maxAmount = 450
+		amount = 0.25
+		maxAmount = 0.25
 	}
 
 }
@@ -60,15 +60,15 @@ WBI_BDB_FUEL_TEMPLATE
 //	RESOURCE
 //	{
 //		 name = LqdHydrogen
-//		 amount = 10800
-//		 maxAmount = 10800
+//		 amount = 6
+//		 maxAmount = 6
 //	}
 //
 //	RESOURCE
 //	{
 //		name = Oxidizer
-//		amount = 720
-//		maxAmount = 720
+//		amount = 0.4
+//		maxAmount = 0.4
 //	}
 //
 //}
@@ -85,8 +85,8 @@ WBI_BDB_FUEL_TEMPLATE
 //	RESOURCE
 //	{
 //		name = LqdHydrogen
-//		amount = 9000
-//		maxAmount = 9000
+//		amount = 5
+//		maxAmount = 5
 //	}
 //
 //}
@@ -103,15 +103,15 @@ WBI_BDB_FUEL_TEMPLATE
 //	RESOURCE
 //	{
 //		name = LqdHydrogen
-//		amount = 18000
-//		maxAmount = 18000
+//		amount = 10
+//		maxAmount = 10
 //	}
 //
 //}
 
 WBI_BDB_FUEL_TEMPLATE
 {
-	name = LFOBubble
+	name = LFOBalloon
 	author = Angel-125
 	shortName = LFO Balloon Tank
 	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidFuel
@@ -121,15 +121,15 @@ WBI_BDB_FUEL_TEMPLATE
 	RESOURCE
 	{
 		 name = LiquidFuel
-		 amount = 927
-		 maxAmount = 927
+		 amount = 0.5175
+		 maxAmount = 0.5175
 	}
 
 	RESOURCE
 	{
 		name = Oxidizer
-		amount = 1133
-		maxAmount = 1133
+		amount = 0.6325
+		maxAmount = 0.6325
 	}
 
 }
@@ -146,8 +146,8 @@ WBI_BDB_FUEL_TEMPLATE
 //	RESOURCE
 //	{
 //		name = MonoPropellant
-//		amount = 1800
-//		maxAmount = 1800
+//		amount = 1
+//		maxAmount = 1
 //	}
 //
 //}
@@ -252,7 +252,7 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 
 }
 
-@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
+@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
 {
 	!RESOURCE[LiquidFuel] {}
 	!RESOURCE[Oxidizer] {}
@@ -263,31 +263,17 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		name = WBIResourceSwitcher
 		enableLogging = True
 		showGUI = False
-
-		//Require a confirmation click before changing resources
 		confirmResourceSwitch = False
-
-		//Short name of the default module template.
-		//This is used when selecting the part in the editor.
-		//User will then right-click on the module to change its type.
 		defaultTemplate = Block 2 Service Module (Standard)
-
-		//name of the template nodes to use
 		templateNodes = WBI_BDB_FUEL_TEMPLATE_BK2_SM
-
-		//Determines if the module allows in-field reconfiguring
 		fieldReconfigurable = False
 		//resourcesToKeep = ElectricCharge
 		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer;MonoPropellant
-
-		//Some containers don't hold as much resources as the template specifies, while others hold more.
-		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
-		//factor into the resource amounts.
 		capacityFactor = 1
 	}
 }
 
-@PART[bluedog_Apollo_Block3_ServiceModule]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
+@PART[bluedog_Apollo_Block3_ServiceModule]:HAS[!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
 {
 	!RESOURCE[LiquidFuel] {}
 	!RESOURCE[Oxidizer] {}
@@ -298,26 +284,12 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		name = WBIResourceSwitcher
 		enableLogging = True
 		showGUI = False
-
-		//Require a confirmation click before changing resources
 		confirmResourceSwitch = False
-
-		//Short name of the default module template.
-		//This is used when selecting the part in the editor.
-		//User will then right-click on the module to change its type.
 		defaultTemplate = Block 3 Service Module (Standard)
-
-		//name of the template nodes to use
 		templateNodes = WBI_BDB_FUEL_TEMPLATE_BK3_SM
-
-		//Determines if the module allows in-field reconfiguring
 		fieldReconfigurable = False
 		//resourcesToKeep = ElectricCharge
 		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer;MonoPropellant
-
-		//Some containers don't hold as much resources as the template specifies, while others hold more.
-		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
-		//factor into the resource amounts.
 		capacityFactor = 1
 	}
 }
@@ -362,7 +334,6 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
 		//factor into the resource amounts.
 		capacityFactor = #$../tank_volume$
-		@capacityFactor /= 1800
 
 		//Name of the logo panel transforms
 		//logoPanelTransforms = logoPanel001
@@ -401,11 +372,12 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer // Does not appear to be implimented. resourcesToKeep is.
 		//resourcesToReplace = ALL
 		capacityFactor = #$../tank_volume$
-		@capacityFactor /= 1800
 	}	
 }
 
 // This should work, but it doesn’t seem to... Hmm...
+//
+// Work's for me.
 @PART[bluedog_atlas1*Tank,bluedog_atlasFairingAdapterTank,bluedog_Vega_Tankage]:NEEDS[WildBlueTools]:AFTER[Bluedog_DB_0]
 {
 	@MODULE[WBIResourceSwitcher]

--- a/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
@@ -109,6 +109,217 @@ WBI_BDB_FUEL_TEMPLATE
 //
 //}
 
+WBI_BDB_FUEL_TEMPLATE
+{
+	name = LFOBubble
+	author = Angel-125
+	shortName = LFO Bubble Tank
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidFuel
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidFuelGlow
+	description = This kit stores liquid fuel and oxidizer. Very thin. Try not to sneeze.
+
+	RESOURCE
+	{
+		 name = LiquidFuel
+		 amount = 927
+		 maxAmount = 927
+	}
+
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 1133
+		maxAmount = 1133
+	}
+
+}
+
+//WBI_BDB_FUEL_TEMPLATE
+//{
+//	name = MonoProp
+//	author = Angel-125
+//	shortName = MonoPropellant
+//	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/Monopropellant
+//	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MonopropellantGlow
+//	description = This kit stores monopropellant.
+//
+//	RESOURCE
+//	{
+//		name = MonoPropellant
+//		amount = 1800
+//		maxAmount = 1800
+//	}
+//
+//}
+
+WBI_BDB_FUEL_TEMPLATE_BK2_SM
+{
+	name = LFO_AP_Bk2_SM
+	author = Angel-125, feat BDB Crew
+	shortName = Block 2 Service Module (Standard)
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidFuel
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidFuelGlow
+	description = This kit stores liquid fuel and oxidizer.
+
+	RESOURCE
+	{
+		 name = LiquidFuel
+		 amount = 450
+		 maxAmount = 450
+	}
+
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 550
+		maxAmount = 550
+	}
+
+	RESOURCE
+	{
+		name = MonoPropellant
+		amount = 100
+		maxAmount = 250
+	}
+
+}
+
+WBI_BDB_FUEL_TEMPLATE_BK2_SM
+{
+	name = MP_AP_Bk2_SM
+	author = Angel-125, feat BDB Crew
+	shortName = Block 2 Service Module (MonoPropellant)
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/Monopropellant
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MonopropellantGlow
+	description = This kit stores all MonoPropellant
+
+	RESOURCE
+	{
+		name = MonoPropellant
+		amount = 1100
+		maxAmount = 1250
+	}
+
+}
+
+WBI_BDB_FUEL_TEMPLATE_BK3_SM
+{
+	name = LFO_AP_Bk3_SM
+	author = Angel-125, feat BDB Crew
+	shortName = Block 3 Service Module (Standard)
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidFuel
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidFuelGlow
+	description = This kit stores liquid fuel and oxidizer.
+
+	RESOURCE
+	{
+		 name = LiquidFuel
+		 amount = 153
+		 maxAmount = 153
+	}
+
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 187
+		maxAmount = 187
+	}
+
+	RESOURCE
+	{
+		name = MonoPropellant
+		amount = 50
+		maxAmount = 100
+	}
+
+}
+
+WBI_BDB_FUEL_TEMPLATE_BK3_SM
+{
+	name = MP_AP_Bk3_SM
+	author = Angel-125, feat BDB Crew
+	shortName = Block 3 Service Module (MonoPropellant)
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/Monopropellant
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MonopropellantGlow
+	description = This kit stores all MonoPropellant
+
+	RESOURCE
+	{
+		name = MonoPropellant
+		amount = 390
+		maxAmount = 440
+	}
+
+}
+
+@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
+{
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+	!RESOURCE[MonoPropellant] {}
+
+	MODULE
+	{
+		name = WBIResourceSwitcher
+		enableLogging = True
+		showGUI = False
+
+		//Require a confirmation click before changing resources
+		confirmResourceSwitch = False
+
+		//Short name of the default module template.
+		//This is used when selecting the part in the editor.
+		//User will then right-click on the module to change its type.
+		defaultTemplate = LFO_AP_Bk2_SM
+
+		//name of the template nodes to use
+		templateNodes = WBI_BDB_FUEL_TEMPLATE_BK2_SM
+
+		//Determines if the module allows in-field reconfiguring
+		fieldReconfigurable = False
+		resourcesToKeep = ElectricCharge
+
+		//Some containers don't hold as much resources as the template specifies, while others hold more.
+		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
+		//factor into the resource amounts.
+		capacityFactor = 1
+	}
+}
+
+@PART[bluedog_Apollo_Block3_ServiceModule]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
+{
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+	!RESOURCE[MonoPropellant] {}
+
+	MODULE
+	{
+		name = WBIResourceSwitcher
+		enableLogging = True
+		showGUI = False
+
+		//Require a confirmation click before changing resources
+		confirmResourceSwitch = False
+
+		//Short name of the default module template.
+		//This is used when selecting the part in the editor.
+		//User will then right-click on the module to change its type.
+		defaultTemplate = LFO_AP_Bk3_SM
+
+		//name of the template nodes to use
+		templateNodes = WBI_BDB_FUEL_TEMPLATE_BK3_SM
+
+		//Determines if the module allows in-field reconfiguring
+		fieldReconfigurable = False
+		resourcesToKeep = ElectricCharge
+
+		//Some containers don't hold as much resources as the template specifies, while others hold more.
+		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
+		//factor into the resource amounts.
+		capacityFactor = 1
+	}
+}
+
 @PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
 {
 	%tank_volume = #$RESOURCE[LiquidFuel]/maxAmount$
@@ -119,8 +330,8 @@ WBI_BDB_FUEL_TEMPLATE
 	
 	MODULE
 	{
-		name = WBIConvertibleStorage
-		enableLogging = False
+		name = WBIResourceSwitcher
+		enableLogging = True
 
 		showGUI = False
 
@@ -136,14 +347,14 @@ WBI_BDB_FUEL_TEMPLATE
 		templateNodes = WBI_BDB_FUEL_TEMPLATE
 
 		//Determines if the module allows in-field reconfiguring
-		fieldReconfigurable = False
+		fieldReconfigurable = false
 
 		//List of all the resources that may be replaced during a template switch. Any resource NOT
 		//on the list will be preserved.
 		//If empty, then all of the part's resources will be cleared during a template switch.
 		//Set to ALL if you want all of the part's resources to be cleared during a template switch.
 		//This exists because mods like TAC-LS like to add resources to parts and we won't know about them at runtime.
-		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer
+		resourcesToReplace = ALL
 		
 		//Some containers don't hold as much resources as the template specifies, while others hold more.
 		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
@@ -178,16 +389,25 @@ WBI_BDB_FUEL_TEMPLATE
 	
 	MODULE
 	{
-		name = WBIConvertibleStorage
+		name = WBIResourceSwitcher
 		enableLogging = False
 		showGUI = False // Does what???
 		confirmResourceSwitch = False
 		defaultTemplate = LHO
 		templateNodes = WBI_BDB_FUEL_TEMPLATE
-		fieldReconfigurable = False
-		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer // Does not appear to be implimented. resourcesToKeep is.
+		fieldReconfigurable = false
+		//resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer // Does not appear to be implimented. resourcesToKeep is.
+		resourcesToReplace = ALL
 		capacityFactor = #$../tank_volume$
 		@capacityFactor /= 1800
+	}	
+}
+
+// This should work, but it doesn’t seem to... Hmm...
+@PART[bluedog_atlas1*Tank,bluedog_atlasFairingAdapterTank,bluedog_Vega_Tankage]:NEEDS[WildBlueTools]:AFTER[Bluedog_DB_0]
+{
+	@MODULE[WBIResourceSwitcher]
+	{
+		@defaultTemplate = LFOBubble
 	}
-	
 }

--- a/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
@@ -254,9 +254,9 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 
 @PART[bluedog_Apollo_Block2_ServiceModule]:HAS[!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
 {
-	!RESOURCE[LiquidFuel] {}
-	!RESOURCE[Oxidizer] {}
-	!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
 
 	MODULE
 	{
@@ -275,9 +275,9 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 
 @PART[bluedog_Apollo_Block3_ServiceModule]:HAS[!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
 {
-	!RESOURCE[LiquidFuel] {}
-	!RESOURCE[Oxidizer] {}
-	!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
 
 	MODULE
 	{
@@ -338,16 +338,6 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		//Name of the logo panel transforms
 		//logoPanelTransforms = logoPanel001
 		//showDecals = true
-	}
-	
-	MODULE
-	{
-		name = ModuleBdbBoiloff
-		CRYOGENICRESOURCE
-		{
-			name = LqdHydrogen
-			boiloffRate = 8
-		}
 	}
 }
 

--- a/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
@@ -30,7 +30,7 @@ WBI_BDB_FUEL_TEMPLATE
 	shortName = LHO
 	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidHydrogen
 	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidHydrogenGlow
-	description = This kit stores single density liquid hydrogen and oxidizer.
+	description = This kit stores normal density liquid hydrogen and oxidizer.
 
 	RESOURCE
 	{
@@ -113,10 +113,10 @@ WBI_BDB_FUEL_TEMPLATE
 {
 	name = LFOBubble
 	author = Angel-125
-	shortName = LFO Bubble Tank
+	shortName = LFO Balloon Tank
 	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidFuel
 	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidFuelGlow
-	description = This kit stores liquid fuel and oxidizer. Very thin. Try not to sneeze.
+	description = This kit stores liquid fuel and oxidizer. The tank has been modified to a monocoque structure that is held by the pressure of the propellants inside. Very thin. Try not to sneeze. Apply WD-40 three times per day.
 
 	RESOURCE
 	{
@@ -270,14 +270,15 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		//Short name of the default module template.
 		//This is used when selecting the part in the editor.
 		//User will then right-click on the module to change its type.
-		defaultTemplate = LFO_AP_Bk2_SM
+		defaultTemplate = Block 2 Service Module (Standard)
 
 		//name of the template nodes to use
 		templateNodes = WBI_BDB_FUEL_TEMPLATE_BK2_SM
 
 		//Determines if the module allows in-field reconfiguring
 		fieldReconfigurable = False
-		resourcesToKeep = ElectricCharge
+		//resourcesToKeep = ElectricCharge
+		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer;MonoPropellant
 
 		//Some containers don't hold as much resources as the template specifies, while others hold more.
 		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
@@ -304,14 +305,15 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		//Short name of the default module template.
 		//This is used when selecting the part in the editor.
 		//User will then right-click on the module to change its type.
-		defaultTemplate = LFO_AP_Bk3_SM
+		defaultTemplate = Block 3 Service Module (Standard)
 
 		//name of the template nodes to use
 		templateNodes = WBI_BDB_FUEL_TEMPLATE_BK3_SM
 
 		//Determines if the module allows in-field reconfiguring
 		fieldReconfigurable = False
-		resourcesToKeep = ElectricCharge
+		//resourcesToKeep = ElectricCharge
+		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer;MonoPropellant
 
 		//Some containers don't hold as much resources as the template specifies, while others hold more.
 		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
@@ -396,8 +398,8 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		defaultTemplate = LHO
 		templateNodes = WBI_BDB_FUEL_TEMPLATE
 		fieldReconfigurable = false
-		//resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer // Does not appear to be implimented. resourcesToKeep is.
-		resourcesToReplace = ALL
+		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer // Does not appear to be implimented. resourcesToKeep is.
+		//resourcesToReplace = ALL
 		capacityFactor = #$../tank_volume$
 		@capacityFactor /= 1800
 	}	
@@ -408,6 +410,6 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 {
 	@MODULE[WBIResourceSwitcher]
 	{
-		@defaultTemplate = LFOBubble
+		@defaultTemplate = LFO Balloon Tank
 	}
 }

--- a/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/WildBlueIndustries/WBITankSwitcher.cfg
@@ -267,8 +267,7 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		defaultTemplate = Block 2 Service Module (Standard)
 		templateNodes = WBI_BDB_FUEL_TEMPLATE_BK2_SM
 		fieldReconfigurable = False
-		//resourcesToKeep = ElectricCharge
-		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer;MonoPropellant
+		resourcesToKeep = ElectricCharge
 		capacityFactor = 1
 	}
 }
@@ -288,90 +287,86 @@ WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		defaultTemplate = Block 3 Service Module (Standard)
 		templateNodes = WBI_BDB_FUEL_TEMPLATE_BK3_SM
 		fieldReconfigurable = False
-		//resourcesToKeep = ElectricCharge
-		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer;MonoPropellant
+		resourcesToKeep = ElectricCharge
 		capacityFactor = 1
 	}
 }
 
-@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
-{
-	%tank_volume = #$RESOURCE[LiquidFuel]/maxAmount$
-	@tank_volume += #$RESOURCE[Oxidizer]/maxAmount$
-	
-	//!RESOURCE[LiquidFuel] {}
-	//!RESOURCE[Oxidizer] {}
-	
-	MODULE
-	{
-		name = WBIResourceSwitcher
-		enableLogging = True
-
-		showGUI = False
-
-		//Require a confirmation click before changing resources
-		confirmResourceSwitch = False
-
-		//Short name of the default module template.
-		//This is used when selecting the part in the editor.
-		//User will then right-click on the module to change its type.
-		defaultTemplate = LFO
-
-		//name of the template nodes to use
-		templateNodes = WBI_BDB_FUEL_TEMPLATE
-
-		//Determines if the module allows in-field reconfiguring
-		fieldReconfigurable = false
-
-		//List of all the resources that may be replaced during a template switch. Any resource NOT
-		//on the list will be preserved.
-		//If empty, then all of the part's resources will be cleared during a template switch.
-		//Set to ALL if you want all of the part's resources to be cleared during a template switch.
-		//This exists because mods like TAC-LS like to add resources to parts and we won't know about them at runtime.
-		resourcesToReplace = ALL
-		
-		//Some containers don't hold as much resources as the template specifies, while others hold more.
-		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
-		//factor into the resource amounts.
-		capacityFactor = #$../tank_volume$
-
-		//Name of the logo panel transforms
-		//logoPanelTransforms = logoPanel001
-		//showDecals = true
-	}
-}
-
-@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LqdHydrogen],@RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
-{
-	%tank_volume = #$RESOURCE[LqdHydrogen]/maxAmount$
-	@tank_volume /= 5
-	@tank_volume += #$RESOURCE[Oxidizer]/maxAmount$
-
-	//!RESOURCE[LqdHydrogen] {}
-	//!RESOURCE[Oxidizer] {}
-	
-	MODULE
-	{
-		name = WBIResourceSwitcher
-		enableLogging = False
-		showGUI = False // Does what???
-		confirmResourceSwitch = False
-		defaultTemplate = LHO
-		templateNodes = WBI_BDB_FUEL_TEMPLATE
-		fieldReconfigurable = false
-		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer // Does not appear to be implimented. resourcesToKeep is.
-		//resourcesToReplace = ALL
-		capacityFactor = #$../tank_volume$
-	}	
-}
-
-// This should work, but it doesn’t seem to... Hmm...
+//@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
+//{
+//	%tank_volume = #$RESOURCE[LiquidFuel]/maxAmount$
+//	@tank_volume += #$RESOURCE[Oxidizer]/maxAmount$
+//	
+//	//!RESOURCE[LiquidFuel] {}
+//	//!RESOURCE[Oxidizer] {}
+//	
+//	MODULE
+//	{
+//		name = WBIResourceSwitcher
+//		enableLogging = True
 //
-// Work's for me.
-@PART[bluedog_atlas1*Tank,bluedog_atlasFairingAdapterTank,bluedog_Vega_Tankage]:NEEDS[WildBlueTools]:AFTER[Bluedog_DB_0]
-{
-	@MODULE[WBIResourceSwitcher]
-	{
-		@defaultTemplate = LFO Balloon Tank
-	}
-}
+//		showGUI = False
+//
+//		//Require a confirmation click before changing resources
+//		confirmResourceSwitch = False
+//
+//		//Short name of the default module template.
+//		//This is used when selecting the part in the editor.
+//		//User will then right-click on the module to change its type.
+//		defaultTemplate = LFO
+//
+//		//name of the template nodes to use
+//		templateNodes = WBI_BDB_FUEL_TEMPLATE
+//
+//		//Determines if the module allows in-field reconfiguring
+//		fieldReconfigurable = false
+//
+//		//List of all the resources that may be replaced during a template switch. Any resource NOT
+//		//on the list will be preserved.
+//		//If empty, then all of the part's resources will be cleared during a template switch.
+//		//Set to ALL if you want all of the part's resources to be cleared during a template switch.
+//		//This exists because mods like TAC-LS like to add resources to parts and we won't know about them at runtime.
+//		resourcesToReplace = ALL
+//		
+//		//Some containers don't hold as much resources as the template specifies, while others hold more.
+//		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
+//		//factor into the resource amounts.
+//		capacityFactor = #$../tank_volume$
+//
+//		//Name of the logo panel transforms
+//		//logoPanelTransforms = logoPanel001
+//		//showDecals = true
+//	}
+//}
+//
+//@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LqdHydrogen],@RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleEngines*]]:NEEDS[WildBlueTools]:FOR[Bluedog_DB_0]
+//{
+//	%tank_volume = #$RESOURCE[LqdHydrogen]/maxAmount$
+//	@tank_volume /= 5
+//	@tank_volume += #$RESOURCE[Oxidizer]/maxAmount$
+//
+//	//!RESOURCE[LqdHydrogen] {}
+//	//!RESOURCE[Oxidizer] {}
+//	
+//	MODULE
+//	{
+//		name = WBIResourceSwitcher
+//		enableLogging = False
+//		showGUI = False // Does what???
+//		confirmResourceSwitch = False
+//		defaultTemplate = LHO
+//		templateNodes = WBI_BDB_FUEL_TEMPLATE
+//		fieldReconfigurable = false
+//		resourcesToReplace = LiquidFuel;LqdHydrogen;Oxidizer // Does not appear to be implimented. resourcesToKeep is.
+//		//resourcesToReplace = ALL
+//		capacityFactor = #$../tank_volume$
+//	}	
+//}
+//
+//@PART[bluedog_atlas1*Tank,bluedog_atlasFairingAdapterTank,bluedog_Vega_Tankage]:NEEDS[WildBlueTools]:AFTER[Bluedog_DB_0]
+//{
+//	@MODULE[WBIResourceSwitcher]
+//	{
+//		@defaultTemplate = LFO Balloon Tank
+//	}
+//}


### PR DESCRIPTION
This is a fairly straightforward modification, I think.
tldr: 
Switch to non-dialog resource switching.
Add balloon tank variety for atlas and friends. (Default doesn't work, my MM-fu is likely failing here. Have some ideas, but is 2 am.)
Add some special handling for block 2/3 service modules, to offer them a MP only variant of each.
(There is probably a much better way to handle this, but this was the quick/dirty/works approach.)

Buttt, its 2 am, and i've only tested it once. If some of the gang could take it for a spin and let me know what's up, that'd be great. Thanks much.