### PR TITLE
Gemini Ejection Seats

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/VanguardTechnologies/GeminiEjectionSeats.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/VanguardTechnologies/GeminiEjectionSeats.cfg
@@ -1,0 +1,18 @@
+@PART[bluedog_Gemini_Crew_A]:NEEDS[VanguardTechnologies]
+{
+	%MODULE[ModuleKrEjectPilot]
+	{
+		%name = ModuleKrEjectPilot
+		%ejectionForce = 100
+		%baseCost = 666
+		%baseMass = 0.1
+		%maxUses = #$../CrewCapacity$
+		%deployedDrag = 30
+		%minAirPressureToOpen = 0.04
+		%semiDeployedFraction = 0.25
+		%semiDeployedHeight = 1.25
+		%deployTime = 0.33
+		%Soundfile = VanguardTechnologies/Sounds/ejectionSound
+		%Volume = 1
+	}
+}


### PR DESCRIPTION
This one is pretty simple, but fun. If the Vanguard Technologies Ejection Seat mod is installed, this adds the ejection part module to the Gemini Crew Module. Simply hit Abort! and watch your courageous kerbalnauts get flung to safety.

Ejection from the pad is possible, but very rough. Much breakdancing involved.