### PR TITLE
Fix RealFuels tank compatibility

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/B9PartSwitch/B9PartSwitchTanks.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/B9PartSwitch/B9PartSwitchTanks.cfg
@@ -54,7 +54,7 @@
 
 // Balloon tanks
 
-@PART[bluedog_agenaLongTank,bluedog_atlas1*Tank,bluedog_atlasFairingAdapterTank,bluedog_Vega*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*],!MODULE[ModuleB9PartSwitch],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch]:FOR[Bluedog_DB_1]
+@PART[bluedog_agenaLongTank,bluedog_atlas1*Tank,bluedog_atlasFairingAdapterTank,bluedog_Vega*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*],!MODULE[ModuleB9PartSwitch],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch,!RealFuels]:FOR[Bluedog_DB_1]
 {
 	%tank_volume = #$RESOURCE[LiquidFuel]/maxAmount$
 	@tank_volume += #$RESOURCE[Oxidizer]/maxAmount$
@@ -130,7 +130,7 @@
 
 // Regular tanks
 
-@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*],!MODULE[ModuleB9PartSwitch],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch]:FOR[Bluedog_DB_1]
+@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*],!MODULE[ModuleB9PartSwitch],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch,!RealFuels]:FOR[Bluedog_DB_1]
 {
 	%tank_volume = #$RESOURCE[LiquidFuel]/maxAmount$
 	@tank_volume += #$RESOURCE[Oxidizer]/maxAmount$
@@ -204,7 +204,7 @@
 	}
 }
 
-@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LqdHydrogen],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*],!MODULE[ModuleB9PartSwitch],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch]:FOR[Bluedog_DB_1]
+@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[LqdHydrogen],@RESOURCE[Oxidizer],!MODULE[ModuleEngines*],!MODULE[ModuleB9PartSwitch],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch,!RealFuels]:FOR[Bluedog_DB_1]
 {
 	%tank_volume = #$RESOURCE[LqdHydrogen]/maxAmount$
 	@tank_volume /= 5
@@ -279,7 +279,7 @@
 	}
 }
 
-@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[MonoPropellant],@MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch]:FOR[Bluedog_DB_1]
+@PART[bluedog*,Bluedog*]:HAS[@RESOURCE[MonoPropellant],@MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch,!RealFuels]:FOR[Bluedog_DB_1]
 {
 	mp_volume = #$RESOURCE[MonoPropellant]/maxAmount$
 	mp_fraction = #$mp_volume$


### PR DESCRIPTION
Using B9PartSwitch tanks prevents RealFuels from autoconverting them, making them unable to hold RealFuels fuels.
Fortunately, ModuleManager makes it a simple thing to fix.