### PR TITLE
Skylab Fixes #3

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_MOL_Lab.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_MOL_Lab.cfg
@@ -12,15 +12,15 @@ MODEL
 	node_stack_bottom = 0.0, -1.5, 0.0, 0.0, -1.0, 0.0, 2
 	CrewCapacity = 2
 	TechRequired = basicScience
-	entryCost = 12000
-	cost = 4000
+	entryCost = 7200
+	cost = 2400
 	category = Science
 	subcategory = 0
 	title = MOS-LS "Mossy" Orbital Laboratory Segment
 	manufacturer = Bluedog Design Bureau
 	description = This mobile laboratory segment was originally designed for use by [REDACTED] before being converted to more peaceful, scientific uses. It can be used to conduct experiments and process data. As well as spy on Kr-[REDACTED].
 	attachRules = 1,0,1,1,0
-	mass = 3
+	mass = 2.1
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3
@@ -55,29 +55,30 @@ MODEL
 	{
 		name = ModuleScienceLab
 		containerModuleIndex = 0
-		dataStorage = 350
+		dataStorage = 450
 		crewsRequired = 1
 		canResetConnectedModules = True
 		canResetNearbyModules = True
 		interactionRange = 5
-		SurfaceBonus = 0.075
-		ContextBonus = 0.15
+		SurfaceBonus = 0.1
+		ContextBonus = 0.25
 		homeworldMultiplier = 0.1
 		RESOURCE_PROCESS
 		{
 			name = ElectricCharge
-			amount = 6
+			amount = 10
 		}
 	}
 
 	MODULE
 	{
 		name = ModuleScienceConverter
+		dataProcessingMultiplier = 0.5 // Multiplier to data processing rate and therefore science rate
 		scientistBonus = 0.25	//Bonus per scientist star - need at least one! So 0.25x - 2.5x 
-		researchTime = 9	    //Larger = slower.  Exponential!
-		scienceMultiplier = 4	//How much science does data turn into?
-		scienceCap = 200	    //How much science can we store before having to transmit?		
-		powerRequirement = 5	//EC/Sec to research
+		researchTime = 7	    //Larger = slower.  Exponential!
+		scienceMultiplier = 3	//How much science does data turn into?
+		scienceCap = 300	    //How much science can we store before having to transmit?		
+		powerRequirement = 3	//EC/Sec to research
 		ConverterName = Research
 		StartActionName = Start Research
 		StopActionName = Stop Research
@@ -129,249 +130,4 @@ MODEL
     		defaultActionGroup = Light
 	}
 	
-}
-
-@PART[bluedog_MOL_Lab]:NEEDS[WildBlueTools]
-{
-	!MODULE[ModuleKerbNetAccess] {}
-	!MODULE[ModuleExperienceManagement] {}
-	
-	MODULE
-	{
-		name = WBIConvertibleMPL
-		enableLogging = True
-
-		//Determines whether or not to show the context menu GUI
-		//NOTE: ModuleMarkOneLab will NOT show the Manage Operations button during flight; no need to.
-		showGUI = True
-
-		//Some containers don't hold as much resources as the template specifies, while others hold more.
-		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
-		//factor into the resource amounts.
-		capacityFactor = 0.25
-
-		//Determines if the part can be reconfigured out in the field.
-		fieldReconfigurable = false
-
-		//name of the template nodes to use
-		templateNodes = BDB_MOL_TEMPLATE
-
-		//Short name of the default module template.
-		//This is used when selecting the part in the editor.
-		//User will then right-click on the module to change its type.
-		defaultTemplate = MOL
-
-		//Name of the logo panel transforms
-		decalsVisible = false
-
-		//If the part has a KIS container, this is the base and max amount
-		baseStorage = 700
-		maxStorage = 700
-
-		opsViewTitle = Mark One Laboratory Extension
-
-		//Snacks
-		resourcesToKeep:NEEDS[SnacksUtils] = ElectricCharge;Snacks
-
-		//Kerbalism
-		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen
-
-		//TAC-LS
-		resourcesToKeep:NEEDS[TacLifeSupport] = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater
-
-		//USI-LS
-		resourcesToKeep:NEEDS[USILifeSupport] = ElectricCharge;Supplies;Mulch;ReplacementParts
-	}
-
-	MODULE
-	{
-		name = WBIModuleWetWorkshop
-		hideObjects = evaElements
-		hideObjectsForTemplates = LFO;CryoFuel
-	}
-
-	MODULE:NEEDS[KIS]
-	{
-		name = ModuleKISInventory
-		maxVolume = 700
-		externalAccess = true
-		internalAccess = true
-		slotsX = 3
-		slotsY = 3
-		slotSize = 50
-		itemIconResolution = 128
-		selfIconResolution = 128
-		openSndPath = KIS/Sounds/containerOpen
-		closeSndPath = KIS/Sounds/containerClose
-		defaultMoveSndPath = KIS/Sounds/itemMove
-	}
-
-	MODULE
-	{
-		name = WBIPropStateHelper
-	}
-}
-
-BDB_MOL_TEMPLATE:NEEDS[WildBlueTools]
-{
-	author = Angel-125
-	name = BDB_MOLMPL
-	title = MOL Mobile Processing Lab
-	shortName = MOLMPL
-	TechRequired = advExploration
-	mass = 1.375
-	requiredResource = Equipment
-	requiredAmount = 550
-	reconfigureSkill = ScienceSkill
-	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
-	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
-	description = Configured as a Mobile Processing Lab, the MOS-LS can perform extensive research on science experiments and clean them for reuse, albiet at reduced capacity compared to the MPL-LG-2 due to its smaller size.
-	toolTip = You can clean experiments just like the MPL-LG-2.
-	toolTipTitle = Your First M.O.L.E. Mobile Processing Lab
-	enableMPLModules = true
-	ignoreMaterialModifier = true
-	templateTags = mole
-
-	MODULE
-	{
-        	name = ModuleExperienceManagement
-        	costPerKerbal = 0
-	}	
-	
-	MODULE
-	{
-		name = ModuleKerbNetAccess
-		MinimumFoV = 17
-		MaximumFoV = 63
-		AnomalyDetection = 0
-		DISPLAY_MODES
-		{
-			Mode = Terrain
-			Mode = Biome
-		}
-		REQUIRED_EFFECTS
-		{
-			Effect = ScienceSkill
-		}
-	}
-
-	MODULE
-	{
-		name = WBIDataTransferUtility
-	}    	
-}
-
-BDB_MOL_TEMPLATE:NEEDS[WildBlueTools]
-{
-	author = Angel-125
-	name = BDB_MOL
-	title = MOL
-	shortName = MOL
-	TechRequired = spaceExploration
-	mass = 1.375
-	requiredResource = Equipment
-	requiredAmount = 550
-	reconfigureSkill = ScienceSkill
-	logoPanel = WildBlueIndustries/MOLE/Decals/MOLELab
-	glowPanel = WildBlueIndustries/MOLE/Decals/MOLELab
-	description = This early mobile laboratory segment is designed to perform basic research about living and working in space.
-	toolTip = As long as you keep a crewmember in the lab and the ResearchKits full, you can conduct basic research for Science!
-	toolTipTitle = Your First MOL
-	enableMPLModules = false
-	includeModuleInfo = true
-	ignoreMaterialModifier = true
-	templateTags = mol 
-	
-	MODULE
-	{
-		name = WBIModuleScienceExperiment
-		experimentID = WBIEmptyExperiment
-		defaultExperiment = WBIEmptyExperiment
-		experimentActionName = Do Nothing
-		resetActionName = Reset Nothing
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = True
-		xmitDataScalar = 0.25
-		dataIsCollectable = True
-		interactionRange = 1.2
-		rerunnable = False
-		resettable = False
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-
-	MODULE
-	{
-		name = WBIModuleScienceExperiment
-		experimentID = WBIEmptyExperiment
-		defaultExperiment = WBIEmptyExperiment
-		experimentActionName = Do Nothing
-		resetActionName = Reset Nothing
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = True
-		xmitDataScalar = 0.25
-		dataIsCollectable = True
-		interactionRange = 1.2
-		rerunnable = False
-		resettable = False
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-
-	MODULE
-	{
-		name = WBIExperimentLab
-		debugMode = false
-		isGUIVisible = false
-		experimentID = WBISpaceResearch
-		ConverterName = Lab Time
-		StartActionName = Start Lab Time
-		StopActionName = Stop Lab Time
-		AutoShutdown = false
-		UseSpecialistBonus = true
-		//Give 25% with 0 stars, 125% with 5 stars.
-		SpecialistEfficiencyFactor = 0.5
-		SpecialistBonusBase = 0.5
-		ExperienceEffect = ScienceSkill
-		GeneratesHeat = false
-		hoursPerCycle = 6
-		crewsRequired = 1
-		minimumSuccess = 40
-		criticalSuccess = 95
-		criticalFail = 20
-		sciencePerCycle = 1.0
-		repairSkill = ScienceSkill
-		repairResource = RocketParts
-		repairAmount = 50
-		defaultExperiment = WBIEmptyExperiment
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 5
-		}
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ResearchKits
-			Ratio = 0.00027777
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = LabTime
-			Ratio = 0.00028
-			DumpExcess = true
-		}
-	}
-
-	RESOURCE
-	{
-		name = ResearchKits
-		amount = 720
-		maxAmount = 720
-		isTweakable = true
-	}
 }

--- a/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_Capsule_Science_Downmass.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_Capsule_Science_Downmass.cfg
@@ -1,4 +1,4 @@
-@PART[bluedog_mercuryPod,bluedog_Gemini_Crew_A,bluedog_Apollo_Block2_Capsule,bluedog_Apollo_Block3_Capsule]
+@PART[bluedog_mercuryPod,bluedog_Gemini_Crew_A,bluedog_Apollo_Block2_Capsule,bluedog_Apollo_Block3_Capsule]:NEEDS[WildBlueTools]
 {
 	@MODULE[ModuleScienceContainer]
 	{

--- a/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_Cargo_Templates.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_Cargo_Templates.cfg
@@ -1,4 +1,4 @@
-B9_TANK_TYPE
+B9_TANK_TYPE:NEEDS[B9PartSwitch,WildBlueTools]
 {
 	name = bdbSupplyEquipment
 	tankMass = 0.0015
@@ -11,7 +11,7 @@ B9_TANK_TYPE
 	}
 }
 
-B9_TANK_TYPE
+B9_TANK_TYPE:NEEDS[B9PartSwitch,WildBlueTools]
 {
 	name = bdbSupplyResearchKits
 	tankMass = 0.0015
@@ -23,8 +23,7 @@ B9_TANK_TYPE
 		unitsPerVolume = 1
 	}
 }
-
-@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#switcherDescription[Cargo]]]:NEEDS[B9PartSwitch]:AFTER[Bluedog_DB_1]
+@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#switcherDescription[Cargo]]]:NEEDS[B9PartSwitch,WildBlueTools]:AFTER[Bluedog_DB_1]
 {
 	@MODULE[ModuleB9PartSwitch]
 	{

--- a/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_Experiment_Slots.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_Experiment_Slots.cfg
@@ -1,4 +1,4 @@
-@PART[bluedog_Apollo_AARDV_Cargo]
+@PART[bluedog_Apollo_AARDV_Cargo]:NEEDS[WildBlueTools]
 {
 	MODULE
 	{
@@ -83,7 +83,7 @@
 	}
 }
 
-@PART[bluedog_MOL_KISmodule]
+@PART[bluedog_MOL_KISmodule]:NEEDS[WildBlueTools]
 {
 	MODULE
 	{
@@ -131,7 +131,7 @@
 
 }
 
-@PART[bluedog_Gemini_Resupply_Capsule]
+@PART[bluedog_Gemini_Resupply_Capsule]:NEEDS[WildBlueTools]
 {
 	MODULE
 	{
@@ -179,7 +179,7 @@
 
 }
 
-@PART[bluedog_Agena_ResupplyContainer]
+@PART[bluedog_Agena_ResupplyContainer]:NEEDS[WildBlueTools]
 {
 	MODULE
 	{

--- a/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_MOL_Science.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_MOL_Science.cfg
@@ -1,0 +1,245 @@
+@PART[bluedog_MOL_Lab]:NEEDS[WildBlueTools]
+{
+	@mass = 1.1 //2.1
+	!MODULE[ModuleKerbNetAccess] {}
+	!MODULE[ModuleExperienceManagement] {}
+	
+	MODULE
+	{
+		name = WBIConvertibleMPL
+		enableLogging = True
+
+		//Determines whether or not to show the context menu GUI
+		//NOTE: ModuleMarkOneLab will NOT show the Manage Operations button during flight; no need to.
+		showGUI = True
+
+		//Some containers don't hold as much resources as the template specifies, while others hold more.
+		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
+		//factor into the resource amounts.
+		capacityFactor = 0.25
+
+		//Determines if the part can be reconfigured out in the field.
+		fieldReconfigurable = false
+
+		//name of the template nodes to use
+		templateNodes = BDB_MOL_TEMPLATE
+
+		//Short name of the default module template.
+		//This is used when selecting the part in the editor.
+		//User will then right-click on the module to change its type.
+		defaultTemplate = BDB_MOL
+
+		//Name of the logo panel transforms
+		decalsVisible = false
+
+		//If the part has a KIS container, this is the base and max amount
+		baseStorage = 700
+		maxStorage = 700
+
+		opsViewTitle = Mark One Laboratory Extension
+
+		//Snacks
+		resourcesToKeep:NEEDS[SnacksUtils] = ElectricCharge;Snacks
+
+		//Kerbalism
+		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen
+
+		//TAC-LS
+		resourcesToKeep:NEEDS[TacLifeSupport] = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater
+
+		//USI-LS
+		resourcesToKeep:NEEDS[USILifeSupport] = ElectricCharge;Supplies;Mulch;ReplacementParts
+	}
+
+	MODULE
+	{
+		name = WBIModuleWetWorkshop
+		hideObjects = evaElements
+		hideObjectsForTemplates = LFO;CryoFuel
+	}
+
+	MODULE:NEEDS[KIS]
+	{
+		name = ModuleKISInventory
+		maxVolume = 700
+		externalAccess = true
+		internalAccess = true
+		slotsX = 3
+		slotsY = 3
+		slotSize = 50
+		itemIconResolution = 128
+		selfIconResolution = 128
+		openSndPath = KIS/Sounds/containerOpen
+		closeSndPath = KIS/Sounds/containerClose
+		defaultMoveSndPath = KIS/Sounds/itemMove
+	}
+
+	MODULE
+	{
+		name = WBIPropStateHelper
+	}
+}
+
+BDB_MOL_TEMPLATE
+{
+	author = Angel-125
+	name = BDB_MOLMPL
+	title = MOL Mobile Processing Lab
+	shortName = MOLMPL
+	TechRequired = advExploration
+	mass = 1
+	requiredResource = Equipment
+	requiredAmount = 300
+	reconfigureSkill = ScienceSkill
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
+	description = Configured as a Mobile Processing Lab, the MOS-LS can perform extensive research on science experiments and clean them for reuse, albiet at reduced capacity compared to the MPL-LG-2 due to its smaller size.
+	toolTip = You can clean experiments just like the MPL-LG-2.
+	toolTipTitle = Your First M.O.L.E. Mobile Processing Lab
+	enableMPLModules = true
+	ignoreMaterialModifier = true
+	templateTags = mole
+
+	MODULE
+	{
+        	name = ModuleExperienceManagement
+        	costPerKerbal = 0
+	}	
+	
+	MODULE
+	{
+		name = ModuleKerbNetAccess
+		MinimumFoV = 17
+		MaximumFoV = 63
+		AnomalyDetection = 0
+		DISPLAY_MODES
+		{
+			Mode = Terrain
+			Mode = Biome
+		}
+		REQUIRED_EFFECTS
+		{
+			Effect = ScienceSkill
+		}
+	}
+
+	MODULE
+	{
+		name = WBIDataTransferUtility
+	}    	
+}
+
+BDB_MOL_TEMPLATE
+{
+	author = Angel-125
+	name = BDB_MOL
+	title = MOL
+	shortName = MOL
+	TechRequired = spaceExploration
+	mass = 1
+	requiredResource = Equipment
+	requiredAmount = 300
+	reconfigureSkill = ScienceSkill
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
+	description = This early mobile laboratory segment is designed to perform basic research about living and working in space.
+	toolTip = As long as you keep a crewmember in the lab and the ResearchKits full, you can conduct basic research for Science!
+	toolTipTitle = Your First MOL
+	enableMPLModules = false
+	includeModuleInfo = true
+	ignoreMaterialModifier = true
+	templateTags = mol 
+	
+	MODULE
+	{
+		name = WBIModuleScienceExperiment
+		experimentID = WBIEmptyExperiment
+		defaultExperiment = WBIEmptyExperiment
+		experimentActionName = Do Nothing
+		resetActionName = Reset Nothing
+		useStaging = False
+		useActionGroups = True
+		hideUIwhenUnavailable = True
+		xmitDataScalar = 0.25
+		dataIsCollectable = True
+		interactionRange = 1.2
+		rerunnable = False
+		resettable = False
+		usageReqMaskInternal = 1
+		usageReqMaskExternal = 8
+	}
+
+	MODULE
+	{
+		name = WBIModuleScienceExperiment
+		experimentID = WBIEmptyExperiment
+		defaultExperiment = WBIEmptyExperiment
+		experimentActionName = Do Nothing
+		resetActionName = Reset Nothing
+		useStaging = False
+		useActionGroups = True
+		hideUIwhenUnavailable = True
+		xmitDataScalar = 0.25
+		dataIsCollectable = True
+		interactionRange = 1.2
+		rerunnable = False
+		resettable = False
+		usageReqMaskInternal = 1
+		usageReqMaskExternal = 8
+	}
+
+	MODULE
+	{
+		name = WBIExperimentLab
+		debugMode = false
+		isGUIVisible = false
+		experimentID = WBISpaceResearch
+		ConverterName = Lab Time
+		StartActionName = Start Lab Time
+		StopActionName = Stop Lab Time
+		AutoShutdown = false
+		UseSpecialistBonus = true
+		//Give 25% with 0 stars, 125% with 5 stars.
+		SpecialistEfficiencyFactor = 0.5
+		SpecialistBonusBase = 0.5
+		ExperienceEffect = ScienceSkill
+		GeneratesHeat = false
+		hoursPerCycle = 6
+		crewsRequired = 1
+		minimumSuccess = 40
+		criticalSuccess = 95
+		criticalFail = 20
+		sciencePerCycle = 1.0
+		repairSkill = ScienceSkill
+		repairResource = RocketParts
+		repairAmount = 50
+		defaultExperiment = WBIEmptyExperiment
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 5
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ResearchKits
+			Ratio = 0.00027777
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LabTime
+			Ratio = 0.00028
+			DumpExcess = true
+		}
+	}
+
+	RESOURCE
+	{
+		name = ResearchKits
+		amount = 720
+		maxAmount = 720
+		isTweakable = true
+	}
+}

--- a/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_OWS_Science.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Skylab/Skylab_OWS_Science.cfg
@@ -1,0 +1,418 @@
+@PART[bluedog_Skylab_OWS]:NEEDS[WildBlueTools]
+{
+	@mass = 5 //25.2
+	!MODULE[ModuleKerbNetAccess] {}
+	!MODULE[ModuleExperienceManagement] {}
+
+	MODULE
+	{
+		name = WBIConvertibleMPL
+		enableLogging = True
+
+		//Determines whether or not to show the context menu GUI
+		showGUI = True
+
+		//Some containers don't hold as much resources as the template specifies, while others hold more.
+		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
+		//factor into the resource amounts.
+		capacityFactor = 11300
+
+		//Crew capacity when inflated
+		inflatedCrewCapacity = 6
+
+		//Determines if the part can be reconfigured out in the field.
+		fieldReconfigurable = true
+
+		//name of the template nodes to use
+		templateNodes = BDB_SKYLAB_TEMPLATE
+		templateTags = orbitalWorkshop
+
+		//Short name of the default module template.
+		//This is used when selecting the part in the editor.
+		//User will then right-click on the module to change its type.
+		defaultTemplate = BDB_Skylab
+
+		//Name of the logo panel transforms
+		decalsVisible = false
+
+		//If the part has a KIS container, this is the base and max amount
+		baseStorage = 2000
+		maxStorage = 10000
+
+		//Snacks
+		resourcesToKeep:NEEDS[SnacksUtils] = ElectricCharge;Snacks
+
+		//Kerbalism
+		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen
+
+		//TAC-LS
+		resourcesToKeep:NEEDS[TacLifeSupport] = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater
+
+		//USI-LS
+		resourcesToKeep:NEEDS[USILifeSupport] = ElectricCharge;Supplies;Mulch;ReplacementParts
+	}
+
+	MODULE
+	{
+		name = WBIModuleWetWorkshop
+		hideObjects = Skylab_WindowCovers
+		hideObjectsForTemplates = Skylab;SkylabMPL
+	}
+
+	MODULE
+	{
+		name = WBIPowerMonitor
+	}
+
+	MODULE
+	{
+		name = WBIPropStateHelper
+	}
+
+	MODULE
+	{
+		name = ModuleAnimateGeneric
+		animationName = Skylab_Window_Anim
+		startEventGUIName = Lights On
+		endEventGUIName = Lights Off
+		actionGUIName = Toggle Lights
+    	defaultActionGroup = Light
+	}
+}
+
+BDB_SKYLAB_TEMPLATE
+{
+	name = BDB_Skylab_CryoFuel
+	author = Angel-125
+	shortName = CryoFuel
+	title = Wet Workshop (Cryo)
+	templateTags = orbitalWorkshop
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidHydrogen
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidHydrogenGlow
+	description = The Wet Workshop concept provides the ability to store liquid fuel and oxidizer just like any other fuel tank. Once in orbit, you can drain the tank of its resources so that it can be converted into habitable space. The conversion might require additional resources.
+	mass = 10
+	requiredResource = Equipment
+	requiredAmount = 2000
+	reconfigureSkill = ConverterSkill
+	CrewCapacity = 0
+	ignoreMaterialModifier = true
+
+	RESOURCE
+	{
+		 name = LqdHydrogen
+		 amount = 3.75
+		 maxAmount = 3.75
+	}
+
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 0.25
+		maxAmount = 0.25
+	}
+}
+
+BDB_SKYLAB_TEMPLATE
+{
+	name = BDB_Skylab_LFO
+	author = Angel-125
+	shortName = LFO
+	title = Wet Workshop
+	templateTags = orbitalWorkshop
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LFO
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LFOGlow
+	description = The Wet Workshop concept provides the ability to store liquid fuel and oxidizer just like any other fuel tank. Once in orbit, you can drain the tank of its resources so that it can be converted into habitable space. The conversion might require additional resources.
+	mass = 10
+	requiredResource = Equipment
+	requiredAmount = 2000
+	reconfigureSkill = ConverterSkill
+	CrewCapacity = 0
+	ignoreMaterialModifier = true
+
+	RESOURCE
+	{
+		 name = LiquidFuel
+		 amount = 0.45
+		 maxAmount = 0.45
+	}
+
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 0.55
+		maxAmount = 0.55
+	}
+}
+
+BDB_SKYLAB_TEMPLATE
+{
+	name = BDB_Skylab_MPL
+	author = Angel-125
+	title = Skylab Mobile Processing Lab
+	shortName = SkylabMPL
+	TechRequired = spaceExploration
+	templateTags = orbitalWorkshop
+	mass = 15
+	requiredResource = Equipment
+	requiredAmount = 2000
+	reconfigureSkill = ScienceSkill
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
+	description = Configured as a Mobile Processing Lab, Skylab can perform extensive research on science experiments and clean them for reuse.
+	toolTip = You can clean experiments just like the MPL-LG-2.
+	toolTipTitle = Skylab Mobile Processing Laboratory
+	enableMPLModules = true
+	ignoreMaterialModifier = true
+	templateTags = mole
+	
+	MODULE
+	{
+		name = ModuleExperienceManagement
+		costPerKerbal = 0
+	}
+
+	MODULE
+	{
+		name = ModuleKerbNetAccess
+		MinimumFoV = 17
+		MaximumFoV = 63
+		AnomalyDetection = 0
+		DISPLAY_MODES
+		{
+			Mode = Terrain
+			Mode = Biome
+		}
+		REQUIRED_EFFECTS
+		{
+			Effect = ScienceSkill
+		}
+	}	
+
+	MODULE
+	{
+		name = WBIDataTransferUtility
+	}    	
+
+}
+
+BDB_SKYLAB_TEMPLATE
+{
+	author = Angel-125
+	name = BDB_Skylab
+	title = Skylab
+	shortName = Skylab
+	TechRequired = spaceExploration
+	templateTags = orbitalWorkshop
+	mass = 15
+	requiredResource = Equipment
+	requiredAmount = 2000
+	reconfigureSkill = ScienceSkill
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
+	description = Big brother to the MOL, Skylab has more lab space and can simultaneously conduct science experiments and process data for additional returns.
+	toolTip = As long as you keep a crewmember in the lab and the ResearchKits full, you can conduct basic research for Science!
+	toolTipTitle = Your First Skylab
+	enableMPLModules = true
+	includeModuleInfo = true
+	ignoreMaterialModifier = true
+	
+	MODULE
+	{
+		name = ModuleExperienceManagement
+		costPerKerbal = 0
+	}
+			
+	MODULE
+	{
+		name = ModuleKerbNetAccess
+		MinimumFoV = 17
+		MaximumFoV = 63
+		AnomalyDetection = 0
+		DISPLAY_MODES
+		{
+			Mode = Terrain
+			Mode = Biome
+		}
+		REQUIRED_EFFECTS
+		{
+			Effect = ScienceSkill
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Create Research Kits
+		StartActionName = Start Research Kits
+		StopActionName = Stop Research Kits
+		AutoShutdown = false
+		GeneratesHeat = false
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ScienceSkill
+		EfficiencyBonus = 1
+		 
+		INPUT_RESOURCE
+		{
+			ResourceName = Ore
+			Ratio = 0.5
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 15
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ResearchKits
+			Ratio = 0.02
+			DumpExcess = false
+		}
+	}
+
+	MODULE
+	{
+		name = WBIModuleScienceExperiment
+		experimentID = WBIEmptyExperiment
+		defaultExperiment = WBIEmptyExperiment
+		experimentActionName = Do Nothing
+		resetActionName = Reset Nothing
+		useStaging = False
+		useActionGroups = True
+		hideUIwhenUnavailable = True
+		xmitDataScalar = 0.25
+		dataIsCollectable = True
+		interactionRange = 1.2
+		rerunnable = False
+		resettable = False
+		usageReqMaskInternal = 1
+		usageReqMaskExternal = 8
+	}
+
+	MODULE
+	{
+		name = WBIModuleScienceExperiment
+		experimentID = WBIEmptyExperiment
+		defaultExperiment = WBIEmptyExperiment
+		experimentActionName = Do Nothing
+		resetActionName = Reset Nothing
+		useStaging = False
+		useActionGroups = True
+		hideUIwhenUnavailable = True
+		xmitDataScalar = 0.25
+		dataIsCollectable = True
+		interactionRange = 1.2
+		rerunnable = False
+		resettable = False
+		usageReqMaskInternal = 1
+		usageReqMaskExternal = 8
+	}
+
+	MODULE
+	{
+		name = WBIModuleScienceExperiment
+		experimentID = WBIEmptyExperiment
+		defaultExperiment = WBIEmptyExperiment
+		experimentActionName = Do Nothing
+		resetActionName = Reset Nothing
+		useStaging = False
+		useActionGroups = True
+		hideUIwhenUnavailable = True
+		xmitDataScalar = 0.25
+		dataIsCollectable = True
+		interactionRange = 1.2
+		rerunnable = False
+		resettable = False
+		usageReqMaskInternal = 1
+		usageReqMaskExternal = 8
+	}
+
+	MODULE
+	{
+		name = WBIModuleScienceExperiment
+		experimentID = WBIEmptyExperiment
+		defaultExperiment = WBIEmptyExperiment
+		experimentActionName = Do Nothing
+		resetActionName = Reset Nothing
+		useStaging = False
+		useActionGroups = True
+		hideUIwhenUnavailable = True
+		xmitDataScalar = 0.25
+		dataIsCollectable = True
+		interactionRange = 1.2
+		rerunnable = False
+		resettable = False
+		usageReqMaskInternal = 1
+		usageReqMaskExternal = 8
+	}
+
+	MODULE
+	{
+		name = WBIExperimentLab
+		debugMode = false
+
+		canCreateExperiments = true
+		experimentCreationSkill = ScienceSkill
+		minimumCreationLevel = 2
+		defaultCreationResource = ResearchKits
+		minimumCreationAmount = 100.0
+		checkCreationResources = true
+
+		isGUIVisible = false
+		experimentID = WBISpaceResearch
+		ConverterName = Lab Time
+		StartActionName = Start Lab Time
+		StopActionName = Stop Lab Time
+		AutoShutdown = false
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.05
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ScienceSkill
+		GeneratesHeat = false
+		hoursPerCycle = 6
+		crewsRequired = 1
+		minimumSuccess = 40
+		criticalSuccess = 95
+		criticalFail = 20
+		sciencePerCycle = 1.0
+		repairSkill = ScienceSkill
+		repairResource = RocketParts
+		repairAmount = 150
+		defaultExperiment = WBIEmptyExperiment
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 5
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ResearchKits
+			Ratio = 0.00055554
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LabTime
+			Ratio = 0.00056
+			DumpExcess = true
+		}
+	}
+
+	MODULE
+	{
+		name = WBIDataTransferUtility
+	}    	
+
+	RESOURCE
+	{
+		name = ResearchKits
+		amount = 0.35840707964601769911504424778764 // 0.00707964601769911504424778761062
+		maxAmount = 0.35840707964601769911504424778764 // 0.00707964601769911504424778761062
+		isTweakable = true
+	}
+}

--- a/Gamedata/Bluedog_DB/Parts/Skylab/bluedog_Skylab_OWS.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Skylab/bluedog_Skylab_OWS.cfg
@@ -18,8 +18,8 @@ PART
 
 	// --- editor parameters ---
 	TechRequired = specializedConstruction
-	entryCost = 24000
-	cost = 12000
+	entryCost = 58000
+	cost = 28800
 	category = Science
 	subcategory = 0
 	title = Skylab OWS
@@ -30,7 +30,7 @@ PART
 	attachRules = 1,0,1,1,0
 
 	// --- standard part parameters ---
-	mass = 3
+	mass = 20
 	dragModelType = default
 	maximum_drag = 0.25
 	minimum_drag = 0.25
@@ -66,15 +66,14 @@ PART
 	{
 		name = ModuleScienceLab
 		containerModuleIndex = 0
-		dataStorage = 1000
+		dataStorage = 1800
 		crewsRequired = 1
 		canResetConnectedModules = True
 		canResetNearbyModules = True
 		interactionRange = 5
 		SurfaceBonus = 0.1
 		ContextBonus = 0.25
-		homeworldMultiplier = 0.2
-
+		homeworldMultiplier = 0.1
 		RESOURCE_PROCESS
 		{
 			name = ElectricCharge
@@ -87,19 +86,44 @@ PART
 		name = ModuleScienceConverter
 		dataProcessingMultiplier = 0.5 // Multiplier to data processing rate and therefore science rate
 		scientistBonus = 0.25	//Bonus per scientist star - need at least one! So 0.25x - 2.5x 
-		researchTime = 7	//Larger = slower.  Exponential!
-		scienceMultiplier = 5	//How much science does data turn into?
-		scienceCap = 800	//How much science can we store before having to transmit?		
+		researchTime = 5	    //Larger = slower.  Exponential!
+		scienceMultiplier = 7	//How much science does data turn into?
+		scienceCap = 1000	    //How much science can we store before having to transmit?		
 		powerRequirement = 5	//EC/Sec to research
-		ConverterName = Data Processing
-		StartActionName = Start Data Processing
-		StopActionName = Stop Data Processing
+		ConverterName = Research
+		StartActionName = Start Research
+		StopActionName = Stop Research
+	}
+	
+	MODULE
+	{
+		name = ModuleKerbNetAccess
+		MinimumFoV = 17
+		MaximumFoV = 63
+		AnomalyDetection = 0
+		DISPLAY_MODES
+		{
+			Mode = Terrain
+			Mode = Biome
+		}
+		REQUIRED_EFFECTS
+		{
+			Effect = ScienceSkill
+		}
 	}
 
 	MODULE
 	{
         name = ModuleExperienceManagement
         costPerKerbal = 0
+	}
+	
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 3500
+		maxAmount = 3500
+		isTweakable = true
 	}
 
 	MODULE:NEEDS[KIS]
@@ -116,429 +140,5 @@ PART
 		openSndPath = KIS/Sounds/containerOpen
 		closeSndPath = KIS/Sounds/containerClose
 		defaultMoveSndPath = KIS/Sounds/itemMove
-	}
-
-
-
-	MODULE
-	{
-		name = WBIConvertibleMPL
-		enableLogging = True
-
-		//Determines whether or not to show the context menu GUI
-		showGUI = True
-
-		//Some containers don't hold as much resources as the template specifies, while others hold more.
-		//Since the resource templates specify base amounts, the capacity factor specifies a multiplier to
-		//factor into the resource amounts.
-		capacityFactor = 11300
-
-		//Crew capacity when inflated
-		inflatedCrewCapacity = 6
-
-		//Determines if the part can be reconfigured out in the field.
-		fieldReconfigurable = true
-
-		//name of the template nodes to use
-		templateNodes = BDB_SKYLAB_TEMPLATE
-		templateTags = orbitalWorkshop
-
-		//Short name of the default module template.
-		//This is used when selecting the part in the editor.
-		//User will then right-click on the module to change its type.
-		defaultTemplate = BDB_Skylab
-
-		//Name of the logo panel transforms
-		decalsVisible = false
-
-		//If the part has a KIS container, this is the base and max amount
-		baseStorage = 2000
-		maxStorage = 10000
-
-		//Snacks
-		resourcesToKeep:NEEDS[SnacksUtils] = ElectricCharge;Snacks
-
-		//Kerbalism
-		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen
-
-		//TAC-LS
-		resourcesToKeep:NEEDS[TacLifeSupport] = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater
-
-		//USI-LS
-		resourcesToKeep:NEEDS[USILifeSupport] = ElectricCharge;Supplies;Mulch;ReplacementParts
-	}
-
-	MODULE
-	{
-		name = WBIModuleWetWorkshop
-		hideObjects = Skylab_WindowCovers
-		hideObjectsForTemplates = Skylab;SkylabMPL
-	}
-
-	MODULE
-	{
-		name = WBIPowerMonitor
-	}
-
-	MODULE
-	{
-		name = WBIPropStateHelper
-	}
-
-
-	RESOURCE
-	{
-		name = ElectricCharge
-		amount = 2500
-		maxAmount = 2500
-		isTweakable = true
-	}
-
-	MODULE
-	{
-		name = ModuleAnimateGeneric
-		animationName = Skylab_Window_Anim
-		startEventGUIName = Lights On
-		endEventGUIName = Lights Off
-		actionGUIName = Toggle Lights
-    	defaultActionGroup = Light
-	}
-	
-}
-
-BDB_SKYLAB_TEMPLATE
-{
-	name = BDB_Skylab_CryoFuel
-	author = Angel-125
-	shortName = CryoFuel
-	title = Wet Workshop (Cryo)
-	templateTags = orbitalWorkshop
-	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidHydrogen
-	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LiquidHydrogenGlow
-	description = The Wet Workshop concept provides the ability to store liquid fuel and oxidizer just like any other fuel tank. Once in orbit, you can drain the tank of its resources so that it can be converted into habitable space. The conversion might require additional resources.
-	mass = 0.325
-	requiredResource = Equipment
-	requiredAmount = 2000
-	reconfigureSkill = ConverterSkill
-	CrewCapacity = 0
-	ignoreMaterialModifier = true
-
-	RESOURCE
-	{
-		 name = LqdHydrogen
-		 amount = 3.75
-		 maxAmount = 3.75
-	}
-
-	RESOURCE
-	{
-		name = Oxidizer
-		amount = 0.25
-		maxAmount = 0.25
-	}
-}
-
-BDB_SKYLAB_TEMPLATE
-{
-	name = BDB_Skylab_LFO
-	author = Angel-125
-	shortName = LFO
-	title = Wet Workshop
-	templateTags = orbitalWorkshop
-	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LFO
-	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LFOGlow
-	description = The Wet Workshop concept provides the ability to store liquid fuel and oxidizer just like any other fuel tank. Once in orbit, you can drain the tank of its resources so that it can be converted into habitable space. The conversion might require additional resources.
-	mass = 0.325
-	requiredResource = Equipment
-	requiredAmount = 2000
-	reconfigureSkill = ConverterSkill
-	CrewCapacity = 0
-	ignoreMaterialModifier = true
-
-	RESOURCE
-	{
-		 name = LiquidFuel
-		 amount = 0.45
-		 maxAmount = 0.45
-	}
-
-	RESOURCE
-	{
-		name = Oxidizer
-		amount = 0.55
-		maxAmount = 0.55
-	}
-}
-
-BDB_SKYLAB_TEMPLATE
-{
-	name = BDB_Skylab_MPL
-	author = Angel-125
-	title = Skylab Mobile Processing Lab
-	shortName = SkylabMPL
-	TechRequired = spaceExploration
-	templateTags = orbitalWorkshop
-	mass = 3
-	requiredResource = Equipment
-	requiredAmount = 2000
-	reconfigureSkill = ScienceSkill
-	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
-	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
-	description = Configured as a Mobile Processing Lab, Skylab can perform extensive research on science experiments and clean them for reuse.
-	toolTip = You can clean experiments just like the MPL-LG-2.
-	toolTipTitle = Skylab Mobile Processing Laboratory
-	enableMPLModules = true
-	ignoreMaterialModifier = true
-	templateTags = mole
-
-	MODULE
-	{
-		name = ModuleKerbNetAccess
-		MinimumFoV = 17
-		MaximumFoV = 63
-		AnomalyDetection = 0
-		DISPLAY_MODES
-		{
-			Mode = Terrain
-			Mode = Biome
-		}
-		REQUIRED_EFFECTS
-		{
-			Effect = ScienceSkill
-		}
-	}	
-
-	MODULE
-	{
-		name = WBIDataTransferUtility
-	}    	
-
-    MODULE
-	{
-		name = WBISciLabOpsView
-		showOpsView = true
-	}
-
-}
-
-BDB_SKYLAB_TEMPLATE
-{
-	author = Angel-125
-	name = BDB_Skylab
-	title = Skylab
-	shortName = Skylab
-	TechRequired = spaceExploration
-	templateTags = orbitalWorkshop
-	mass = 3
-	requiredResource = Equipment
-	requiredAmount = 2000
-	reconfigureSkill = ScienceSkill
-	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
-	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/MOLELab
-	description = Big brother to the MOL, Skylab has more lab space and can simultaneously conduct science experiments and process data for additional returns.
-	toolTip = As long as you keep a crewmember in the lab and the ResearchKits full, you can conduct basic research for Science!
-	toolTipTitle = Your First Skylab
-	enableMPLModules = true
-	includeModuleInfo = true
-	ignoreMaterialModifier = true
-	
-	MODULE
-	{
-		name = ModuleKerbNetAccess
-		MinimumFoV = 17
-		MaximumFoV = 63
-		AnomalyDetection = 0
-		DISPLAY_MODES
-		{
-			Mode = Terrain
-			Mode = Biome
-		}
-		REQUIRED_EFFECTS
-		{
-			Effect = ScienceSkill
-		}
-	}
-	
-   	MODULE
-	{
-		name = WBISciLabOpsView
-		showOpsView = true
-	}
-
-	MODULE
-	{
-		name = ModuleResourceConverter
-		ConverterName = Create Research Kits
-		StartActionName = Start Research Kits
-		StopActionName = Stop Research Kits
-		AutoShutdown = false
-		GeneratesHeat = false
-		UseSpecialistBonus = true
-		SpecialistEfficiencyFactor = 0.2
-		SpecialistBonusBase = 0.05
-		ExperienceEffect = ScienceSkill
-		EfficiencyBonus = 1
-		 
-		INPUT_RESOURCE
-		{
-			ResourceName = Ore
-			Ratio = 0.5
-		}
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 15
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = ResearchKits
-			Ratio = 0.02
-			DumpExcess = false
-		}
-	}
-
-	MODULE
-	{
-		name = WBIModuleScienceExperiment
-		experimentID = WBIEmptyExperiment
-		defaultExperiment = WBIEmptyExperiment
-		experimentActionName = Do Nothing
-		resetActionName = Reset Nothing
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = True
-		xmitDataScalar = 0.25
-		dataIsCollectable = True
-		interactionRange = 1.2
-		rerunnable = False
-		resettable = False
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-
-	MODULE
-	{
-		name = WBIModuleScienceExperiment
-		experimentID = WBIEmptyExperiment
-		defaultExperiment = WBIEmptyExperiment
-		experimentActionName = Do Nothing
-		resetActionName = Reset Nothing
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = True
-		xmitDataScalar = 0.25
-		dataIsCollectable = True
-		interactionRange = 1.2
-		rerunnable = False
-		resettable = False
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-
-	MODULE
-	{
-		name = WBIModuleScienceExperiment
-		experimentID = WBIEmptyExperiment
-		defaultExperiment = WBIEmptyExperiment
-		experimentActionName = Do Nothing
-		resetActionName = Reset Nothing
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = True
-		xmitDataScalar = 0.25
-		dataIsCollectable = True
-		interactionRange = 1.2
-		rerunnable = False
-		resettable = False
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-
-	MODULE
-	{
-		name = WBIModuleScienceExperiment
-		experimentID = WBIEmptyExperiment
-		defaultExperiment = WBIEmptyExperiment
-		experimentActionName = Do Nothing
-		resetActionName = Reset Nothing
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = True
-		xmitDataScalar = 0.25
-		dataIsCollectable = True
-		interactionRange = 1.2
-		rerunnable = False
-		resettable = False
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-
-	MODULE
-	{
-		name = WBIExperimentLab
-		debugMode = false
-
-		canCreateExperiments = true
-		experimentCreationSkill = ScienceSkill
-		minimumCreationLevel = 2
-		defaultCreationResource = ResearchKits
-		minimumCreationAmount = 100.0
-		checkCreationResources = true
-
-		isGUIVisible = false
-		experimentID = WBISpaceResearch
-		ConverterName = Lab Time
-		StartActionName = Start Lab Time
-		StopActionName = Stop Lab Time
-		AutoShutdown = false
-		UseSpecialistBonus = true
-		SpecialistEfficiencyFactor = 0.05
-		SpecialistBonusBase = 0.05
-		ExperienceEffect = ScienceSkill
-		GeneratesHeat = false
-		hoursPerCycle = 6
-		crewsRequired = 1
-		minimumSuccess = 40
-		criticalSuccess = 95
-		criticalFail = 20
-		sciencePerCycle = 1.0
-		repairSkill = ScienceSkill
-		repairResource = RocketParts
-		repairAmount = 150
-		defaultExperiment = WBIEmptyExperiment
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 5
-		}
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ResearchKits
-			Ratio = 0.00055554
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = LabTime
-			Ratio = 0.00056
-			DumpExcess = true
-		}
-	}
-
-	MODULE
-	{
-		name = WBIDataTransferUtility
-	}    	
-
-	RESOURCE
-	{
-		name = ResearchKits
-		amount = 80
-		maxAmount = 80
-		isTweakable = true
 	}
 }


### PR DESCRIPTION
Skylab Changes:
* Fixed bludedog_Skylab_OWS ResearchKits amount being ridiculously high
* Increased ElectricCharge on bludedog_Skylab_OWS to 3500
* Changed bludedog_Skylab_OWS ModuleScienceConverter to match stock science lab in everything but science held (it was draining the batteries WAY to fast)
* Moved bludedog_Skylab_OWS WBIConvertibleMPL module and templates to Skylab_OWS_Science cfg. Without WildBlueTools installed, Skylab defaults to a MPL.

Gemini Changes:
* Changed bluedog_MOL_Lab ModuleScienceConverter to Jso suggeted tweaks
* Moved bluedog_MOL_Lab WBIConvertibleMPL module and templates to Skylab_MOL_Science cfg. Without WildBlueTools installed, Skylab defaults to a MPL.

General Changes:
* Moved Skylab and Gemini MOL WBT modules into seperate cfgs. ( Skylab_OWS_Science and Skylab_MOL_Science respectively)
* Added ":NEEDS[WildBlueTools]" to all Skylab WBT configs to allow play without WildBlueTools