### PR TITLE
Adding/dusting off Rescale PF SLA

### DIFF
--- a/BD_Extras (No Warranty)/Saturn_Rescale.cfg
+++ b/BD_Extras (No Warranty)/Saturn_Rescale.cfg
@@ -216,3 +216,107 @@
     @maxAmount = 3775
     }
 }
+
++PART[bluedog_Saturn_S4B_375mFairingBase]:HAS[@MODULE[ModuleProceduralFairing]]:NEEDS[ProceduralFairings]
+{
+	@name ^= :$:_PF_adaptor:
+	// @title ^= :$: PF Interstage Adaptor:
+	@title = Sarnus-SIVB 4.25m PF Interstage Adaptor
+	
+	// Modifier for the base size to account for PF shrinking
+	// the part by the fairing wall width.
+	// Fairing wall width: 0.04 * scale size
+	%extraBaseRadius = #$MODULE[ModuleProceduralFairing]/baseRadius$
+	@extraBaseRadius *= 2
+	@extraBaseRadius *= 0.04
+	
+	// Hold the original fairing diameter in tempBaseSize, and set scale
+	// to the scale needed to get to 1 meter. PF expects a 1 meter part.
+	// Scale is adjusted to account for fairing wall.
+	%tempBaseSize = #$MODULE[ModuleProceduralFairing]/baseRadius$
+	//%tempBaseSize = 1.5625
+	%tempScaleSize = #$tempBaseSize$
+	@tempScaleSize += #$extraBaseRadius$
+	@tempScaleSize *= 2 
+	@tempBaseSize *= 2
+	@tempScaleSize /= #$tempBaseSize$
+	%scale = #$tempScaleSize$
+	@scale /= #$tempBaseSize$
+	%rescaleFactor = 1
+	// Scale the node positions
+	@node_stack_top[1,,] *= #$scale$
+	@node_stack_bottom[1,,] *= #$scale$
+	
+	// Save the top node position. Everything will shift by this amount
+	// to move the top node to position 0. PF starts the fairing
+	// at height 0.
+	@extraNodeShift = -0.05
+	%tempShift = #$node_stack_top[1,,]$
+	// Part specific adjustment
+	@tempShift += #$extraNodeShift$
+	
+	// Scale and adjust model position
+	@MODEL
+	{
+		%position = 0.0, 0.0, 0.0
+		@position[1,,] -= #$../tempShift$
+		%scale = #$../scale$, $../scale$, $../scale$
+	}
+	
+	// Adjust node positions
+	@node_stack_top[1,,] -= #$tempShift$
+	@node_stack_bottom[1,,] -= #$tempShift$
+	%node_stack_top1   = 0.0, 3.0, 0.0, 0.0, 1.0, 0.0, 2
+	
+	node_stack_connect01 = 0.5, 0.000, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_connect02 = 0.5, 0.000, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_connect03 = 0.5, 0.000, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_connect04 = 0.5, 0.000, 0.0, 0.0, 1.0, 0.0, 0
+	
+	MODULE
+	{
+		name = ProceduralFairingBase
+		// baseSize = 1.15
+		// sideThickness = 0.05
+		// verticalStep = 0.1
+	}
+	
+	MODULE
+	{
+		name = KzNodeNumberTweaker
+		nodePrefix = connect
+		maxNumber = 4
+		numNodes = 2
+		// radius = 0.625
+		shouldResizeNodes = False
+	}
+
+	MODULE
+	{
+		name = ProceduralFairingAdapter
+		baseSize = 4.25
+		topSize  = 2.5
+		height= 6.6
+		extraHeight = 0
+		costPerTonne=1000
+		specificMass=0.0064, 0.0130, 0.0098, 0
+		specificBreakingForce =6050
+		specificBreakingTorque=6050
+		dragAreaScale = 1.5
+	}
+	
+	MODULE
+	{
+		name = ModuleDecouple
+		ejectionForce = 0
+		explosiveNodeID = top1
+	}
+	
+	MODULE
+	{
+		name = KzFairingBaseShielding
+	}
+	
+	!MODULE[ModuleProceduralFairing] {}
+	!MODULE[ModuleCargoBay] {}
+}


### PR DESCRIPTION
Addresses #317, at least for the moment. This is in the extras/rescale config in any case, so it shouldn't affect anyone who doesn't go looking for it.

Adds a 4.25 m Procedural Fairings SLA adapter for the rescaled/upscaled Saturn config. Requires PF, naturally.