### PR TITLE
Change NEEDS:[Sigma] to NEEDS:[SigmaDimensions] to prevent problems when other Sigma mods are installed

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
@@ -22,7 +22,7 @@ BDBRESCALECONFIG
 	ballastFactorS4B = 1
 }
 
-@BDBRESCALECONFIG:NEEDS[Sigma]:FOR[zzzBluedog_DB_0]
+@BDBRESCALECONFIG:NEEDS[SigmaDimensions]:FOR[zzzBluedog_DB_0]
 {
 	@systemScale = #$@SigmaDimensions/Resize$
 }


### PR DESCRIPTION
SigmaDimensions is the name of the DLL so MM will read it with no problem