### PR TITLE
Saturn S-1B/S-1E balance tweaks.

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_H1C.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_H1C.cfg
@@ -27,7 +27,7 @@ MODEL
 	manufacturer = Bluedog Design Bureau
 	description = An upgrade over the ageing LVT-30, this 1.25m lifter engine saves weight by removing the gimbal hardware. Good for adding TWR to a launcher, but make sure that you have some other form of control.
 	attachRules = 1,0,1,0,0
-	mass = 1.25
+	mass = 0.83
 	// heatConductivity = 0.06 // half default
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.8 // engine nozzles are good at radiating.

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_H1D.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_H1D.cfg
@@ -27,7 +27,7 @@ MODEL
 	manufacturer = Bluedog Design Bureau
 	description = An upgrade over the ageing LVT-45, this 1.25m lifter engine has high aspirations.
 	attachRules = 1,0,1,0,0
-	mass = 1.5
+	mass = .95
 	// heatConductivity = 0.06 // half default
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.8 // engine nozzles are good at radiating.

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1E_EngineMount.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1E_EngineMount.cfg
@@ -23,7 +23,7 @@ MODEL
 	manufacturer = Bluedog Design Bureau
 	description = 3.75m structural engine mount for the Sarnus S-IE stage. Mount a 'Regor' engine in the center, and two 'Finch' verniers to the outside for roll control.
 	attachRules = 1,1,1,1,0
-	mass = 1.45
+	mass = 1.05 // 1.45
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1E_Tankage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1E_Tankage.cfg
@@ -21,7 +21,7 @@ MODEL
 	manufacturer = Bluedog Design Bureau
 	description = Developed to replace the clustered tank of the Sarnus S1 first tank, this tank is a bit lighter (not really) and has a bit more fuel, while keeping the same length.
 	attachRules = 1,1,1,1,0
-	mass = 9.375
+	mass = 7.375 // 9.375
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3
@@ -37,17 +37,17 @@ MODEL
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 6750
-		maxAmount = 6750
-		//amount = 7245
-		//maxAmount = 7245
+		//amount = 6750
+		//maxAmount = 6750
+		amount = 7371
+		maxAmount = 7371
 	}
 	RESOURCE
 	{
 		name = Oxidizer
-		amount = 8250
-		maxAmount = 8250
-		//amount = 8855
-		//maxAmount = 8855
+		//amount = 8250
+		//maxAmount = 8250
+		amount = 9009
+		maxAmount = 9009
 	}
 }

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1_Tankage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1_Tankage.cfg
@@ -37,17 +37,17 @@ MODEL
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 6255
-		maxAmount = 6255
-		//amount = 7245
-		//maxAmount = 7245
+		//amount = 6255
+		//maxAmount = 6255
+		amount = 7245
+		maxAmount = 7245
 	}
 	RESOURCE
 	{
 		name = Oxidizer
-		amount = 7645
-		maxAmount = 7645
-		//amount = 8855
-		//maxAmount = 8855
+		//amount = 7645
+		//maxAmount = 7645
+		amount = 8855
+		maxAmount = 8855
 	}
 }


### PR DESCRIPTION
Changed the H-1D/C weights to be in line with Titan/Real Life weights instead of copying stock weights. Added fuel to S-1B and S-1E tankage to match other BDB volumes. Shaved small amounts of weight from S-1E tankage and engine mount to better align dry mass weight with ETS goals.