### PR TITLE
Fixed ableEngine OP at sea level.

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/EarlyRockets/bluedog_ableEngine.cfg
+++ b/Gamedata/Bluedog_DB/Parts/EarlyRockets/bluedog_ableEngine.cfg
@@ -104,7 +104,7 @@ MODEL
 		atmosphereCurve
 		{
 			key = 0 270
-			key = 1 240
+			key = 1 85
 			key = 7 0.001
 		}
 	}


### PR DESCRIPTION
reduced sea level ISP to 85 to match ableStar and AJ10 settings, also matches with the description about the engine being optimized for vacuum.