### PR TITLE
Add missing RT modules to probes. Add Missing RT modules to antennas.

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Antennas.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Antennas.cfg
@@ -480,3 +480,230 @@
 	
 	%MODULE[ModuleSPUPassive] {}
 }
+
+@PART[bluedog_Apollo_Block3_HGA]:NEEDS[RemoteTech] //Kane-11-CDA
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0DishRange = 0
+                %Mode1DishRange = 12500000 // 0.25 range, 0.25 dishes
+                %EnergyCost = 0.5
+                %DishAngle = 10 // 10 versus 20 orig.
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.2
+                        %PacketSize = 5
+                        %PacketResourceCost = 15.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Apollo_Block5_HGA]:NEEDS[RemoteTech] //Kane-11-CDA
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0DishRange = 0
+                %Mode1DishRange = 25000000 // 0.50 range, 0.50 dishes
+                %EnergyCost = 0.5
+                %DishAngle = 15 // 15 versus 20 orig.
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.2
+                        %PacketSize = 5
+                        %PacketResourceCost = 15.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_LEM_Ascent_Antenna1]:NEEDS[RemoteTech] //MEM-WCT Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 0
+                %Mode1OmniRange = 15000
+                %EnergyCost = 0.01 // Low cost for low range?
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.35
+                        %PacketSize = 2
+                        %PacketResourceCost = 12.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_LEM_Ascent_Antenna2]:NEEDS[RemoteTech] //MEM-SSC Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 0
+                %Mode1OmniRange = 150000
+                %EnergyCost = 0.05
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.35
+                        %PacketSize = 2
+                        %PacketResourceCost = 12.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Skylab_DisconeAntenna]:NEEDS[RemoteTech] //Hokulani-DCA Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 50000
+                %Mode1OmniRange = 2000000
+                %EnergyCost = 0.1
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.35
+                        %PacketSize = 2
+                        %PacketResourceCost = 12.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Saturn_VFB_Dish]:NEEDS[RemoteTech] // Sarnus-BFBMa(76) Dish
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0DishRange = 0
+                %Mode1DishRange = 3.84E+10 // Specs borrowed from Coatl Verona Dish
+                %EnergyCost = 0.8
+                %DishAngle = 7.5
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.45
+                        %PacketSize = 4
+                        %PacketResourceCost = 20.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Pioneer6_TopAntenna]:NEEDS[RemoteTech] // PIO6E-PWD Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 80000 // Specs borrowed from Coatl CA-A07 config
+                %Mode1OmniRange = 2800000
+                %EnergyCost = 0.15
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.65
+                        %PacketSize = 2
+                        %PacketResourceCost = 10.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Pioneer6_BottomAntenna]:NEEDS[RemoteTech] // PIO6E-SRE Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 40000 // Specs a total guess
+                %Mode1OmniRange = 1400000
+                %EnergyCost = 0.10
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.65
+                        %PacketSize = 2
+                        %PacketResourceCost = 10.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Probes.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Probes.cfg
@@ -335,3 +335,180 @@
 		}
 	}
 }
+
+@PART[bluedog_Apollo_AARDV_Control]:NEEDS[RemoteTech]
+{
+
+    %MODULE[ModuleSPU] {}
+
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+@PART[bluedog_Apollo_Subsatellite_Core]:NEEDS[RemoteTech]
+{
+
+    %MODULE[ModuleSPU] {}
+
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+@PART[bluedog_CentaurT_Avionics]:NEEDS[RemoteTech]
+{
+
+    %MODULE[ModuleSPU] {}
+
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+@PART[bluedog_Vanguard]:NEEDS[RemoteTech]
+{
+
+        %MODULE[ModuleSPU] {}
+
+        !MODULE[ModuleDataTransmitter] {}
+
+        %TechRequired = start 
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 300000
+                %Mode1OmniRange = 1500000
+                %EnergyCost = 0.005
+                %MaxQ = 6000
+
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.6
+                        %PacketSize = 2
+                        %PacketResourceCost = 1.5
+                }
+        }
+}
+
+@PART[bluedog_LunarOrbiter_Core]:NEEDS[RemoteTech]
+{
+
+    %MODULE[ModuleSPU] {}
+
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+@PART[bluedog_Pioneer6_Core]:NEEDS[RemoteTech]
+{
+
+    %MODULE[ModuleSPU] {}
+
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+@PART[bluedog_Saturn_S4B_InstrumentUnit]:NEEDS[RemoteTech]
+{
+
+    %MODULE[ModuleSPU] {}
+
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+@PART[bluedog_Skylab_ATM]:NEEDS[RemoteTech]
+{
+
+    %MODULE[ModuleSPU] {}
+
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+@PART[bluedog_Skylab_MDA]:NEEDS[RemoteTech]
+{
+
+    %MODULE[ModuleSPU] {}
+
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}


### PR DESCRIPTION
(I'm going to leave this as an open PR rather than merging, as long as i've been out of the loop.)

This should add remotetech support to the newer parts that were missing from the compatibility patches.

The numbers look ok to me/my game doesn't crash, but it wouldn't hurt if a second set of (non-2am) eyes looked it over before merging.