### PR TITLE
Agena Medium tank "negative cost if empty" fix

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Agena/bluedog_agenaMediumTank.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Agena/bluedog_agenaMediumTank.cfg
@@ -14,7 +14,7 @@ MODEL
 	node_attach = 0.4688, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 	TechRequired = generalRocketry
 	entryCost = 500
-	cost = 100
+	cost = 185
 	category = FuelTank
 	subcategory = 0
 	title = Belle-140 Liquid Fuel Tank


### PR DESCRIPTION
... I forgot if in stock enviroment or once converted in modded one with cryo fuels, but it goes negative when emptied (not alligned anyway in fuel load-cost in game heavily, calling for bad problems in career mode)