### PR TITLE
Patched for FAR

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Atlas/bluedog_Atlas_LR101_Radial.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Atlas/bluedog_Atlas_LR101_Radial.cfg
@@ -153,3 +153,11 @@ MODEL
 		useEvent = True
 	}
 }
+
+@PART[bluedog_Atlas_LR101_Radial]:AFTER[FerramAerospaceResearch]
+{
+    @MODULE[GeometryPartModule]
+    {
+        %forceUseColliders = True
+    }
+} 


### PR DESCRIPTION
Adds MM patch directly to the source file to force FAR to calculate drag based on the colider for the part rather than the part geometry itself.   APPEARS that FAR is having issues with multiple pivot points and the small size of the multi axis moving part.