### PR TITLE
SETIRebalance + RemoteTech compatibility, minor Realfuels stuff

### DIFF
--- a/BD_Extras (No Warranty)/RealFuels-Dev/RealFuels-Stockalike/BDB/RF_BDB_Saturn.cfg
+++ b/BD_Extras (No Warranty)/RealFuels-Dev/RealFuels-Stockalike/BDB/RF_BDB_Saturn.cfg
@@ -278,6 +278,62 @@
 	}
 }
 
+@PART[bluedog_J2A2]:NEEDS[RealFuels,!RealismOverhaul]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		ignitions = 5
+		ullage = True
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 16.104
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 5.5
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 436
+			@key,1 = 1 200
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesRF
+		configuration = LqdHydrogen+LqdOxygen
+		CONFIG
+		{
+			name = LqdHydrogen+LqdOxygen
+			maxThrust = #$/MODULE[ModuleEnginesRF]/maxThrust$
+			massMult = 1
+			ignitions = 5
+			//throttle = 1
+			ullage = True
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 16.104
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 5.5
+			}
+			atmosphereCurve
+			{
+				key = 0 446
+				key = 1 200
+			}
+		}
+	}
+}
+
 @PART[bluedog_J2_Toroidal]:NEEDS[RealFuels,!RealismOverhaul]
 {
 	@MODULE[ModuleEngines*]

--- a/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Antennas.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Antennas.cfg
@@ -1,4 +1,4 @@
-@PART[bluedog_dipole]:NEEDS[RemoteTech] //DP-75 Antenna
+@PART[bluedog_dipole]:NEEDS[RemoteTech!SETIRebalance] //DP-75 Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -26,7 +26,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_domeAntenna]:NEEDS[RemoteTech] //MSC Dome Antenna
+@PART[bluedog_domeAntenna]:NEEDS[RemoteTech!SETIRebalance] //MSC Dome Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -54,7 +54,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_LOantenna]:NEEDS[RemoteTech] //A23 Omni Antenna
+@PART[bluedog_LOantenna]:NEEDS[RemoteTech!SETIRebalance] //A23 Omni Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -82,7 +82,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_LOdish]:NEEDS[RemoteTech] //A66 Communications Dish
+@PART[bluedog_LOdish]:NEEDS[RemoteTech!SETIRebalance] //A66 Communications Dish
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -111,7 +111,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_rangerDish]:NEEDS[RemoteTech] //OVBR-1 Communications Dish
+@PART[bluedog_rangerDish]:NEEDS[RemoteTech!SETIRebalance] //OVBR-1 Communications Dish
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -140,7 +140,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_telstar]:NEEDS[RemoteTech] //F21 Helical Antenna
+@PART[bluedog_telstar]:NEEDS[RemoteTech!SETIRebalance] //F21 Helical Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -167,7 +167,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_mariner2Antenna]:NEEDS[RemoteTech] //A27-C Antenna
+@PART[bluedog_mariner2Antenna]:NEEDS[RemoteTech!SETIRebalance] //A27-C Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -194,7 +194,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_mariner4Antenna]:NEEDS[RemoteTech] //N100 Omni Antenna
+@PART[bluedog_mariner4Antenna]:NEEDS[RemoteTech!SETIRebalance] //N100 Omni Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -222,7 +222,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_mariner4Dish]:NEEDS[RemoteTech] //J15-D Communications Dish
+@PART[bluedog_mariner4Dish]:NEEDS[RemoteTech!SETIRebalance] //J15-D Communications Dish
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -251,7 +251,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_scimitar]:NEEDS[RemoteTech] //WPT Scimitar Antenna
+@PART[bluedog_scimitar]:NEEDS[RemoteTech!SETIRebalance] //WPT Scimitar Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -279,7 +279,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_simpleAntenna]:NEEDS[RemoteTech] //KD2 Antenna
+@PART[bluedog_simpleAntenna]:NEEDS[RemoteTech!SETIRebalance] //KD2 Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -307,7 +307,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_agenaAntenna]:NEEDS[RemoteTech] //Belle B81 Command Antenna
+@PART[bluedog_agenaAntenna]:NEEDS[RemoteTech!SETIRebalance] //Belle B81 Command Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -335,7 +335,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_solarAntenna]:NEEDS[RemoteTech] //M17 Solar Antenna
+@PART[bluedog_solarAntenna]:NEEDS[RemoteTech!SETIRebalance] //M17 Solar Antenna
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -363,7 +363,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_mercuryScience]:NEEDS[RemoteTech] //Hermes SAM
+@PART[bluedog_mercuryScience]:NEEDS[RemoteTech!SETIRebalance] //Hermes SAM
 {
 	!MODULE[ModuleDataTransmitter] {}
 	
@@ -395,7 +395,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_MOL_rackDish]:NEEDS[RemoteTech] //MOS-MCL Communications Dish
+@PART[bluedog_MOL_rackDish]:NEEDS[RemoteTech!SETIRebalance] //MOS-MCL Communications Dish
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -424,7 +424,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_Apollo_Block2_HGA]:NEEDS[RemoteTech] //Kane-11-CDA 
+@PART[bluedog_Apollo_Block2_HGA]:NEEDS[RemoteTech!SETIRebalance] //Kane-11-CDA 
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -453,7 +453,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_malhenaSolar]:NEEDS[RemoteTech] //Leo-010SM
+@PART[bluedog_malhenaSolar]:NEEDS[RemoteTech!SETIRebalance] //Leo-010SM
 {
 	!MODULE[ModuleDataTransmitter] {}
 
@@ -481,7 +481,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_Apollo_Block3_HGA]:NEEDS[RemoteTech] //Kane-11-CDA
+@PART[bluedog_Apollo_Block3_HGA]:NEEDS[RemoteTech!SETIRebalance] //Kane-11-CDA
 {
         !MODULE[ModuleDataTransmitter] {}
 
@@ -510,7 +510,7 @@
         %MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_Apollo_Block5_HGA]:NEEDS[RemoteTech] //Kane-11-CDA
+@PART[bluedog_Apollo_Block5_HGA]:NEEDS[RemoteTech!SETIRebalance] //Kane-11-CDA
 {
         !MODULE[ModuleDataTransmitter] {}
 
@@ -539,7 +539,7 @@
         %MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_LEM_Ascent_Antenna1]:NEEDS[RemoteTech] //MEM-WCT Antenna
+@PART[bluedog_LEM_Ascent_Antenna1]:NEEDS[RemoteTech!SETIRebalance] //MEM-WCT Antenna
 {
         !MODULE[ModuleDataTransmitter] {}
 
@@ -567,7 +567,7 @@
         %MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_LEM_Ascent_Antenna2]:NEEDS[RemoteTech] //MEM-SSC Antenna
+@PART[bluedog_LEM_Ascent_Antenna2]:NEEDS[RemoteTech!SETIRebalance] //MEM-SSC Antenna
 {
         !MODULE[ModuleDataTransmitter] {}
 
@@ -595,7 +595,7 @@
         %MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_Skylab_DisconeAntenna]:NEEDS[RemoteTech] //Hokulani-DCA Antenna
+@PART[bluedog_Skylab_DisconeAntenna]:NEEDS[RemoteTech!SETIRebalance] //Hokulani-DCA Antenna
 {
         !MODULE[ModuleDataTransmitter] {}
 
@@ -623,7 +623,7 @@
         %MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_Saturn_VFB_Dish]:NEEDS[RemoteTech] // Sarnus-BFBMa(76) Dish
+@PART[bluedog_Saturn_VFB_Dish]:NEEDS[RemoteTech!SETIRebalance] // Sarnus-BFBMa(76) Dish
 {
         !MODULE[ModuleDataTransmitter] {}
 
@@ -652,7 +652,7 @@
         %MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_Pioneer6_TopAntenna]:NEEDS[RemoteTech] // PIO6E-PWD Antenna
+@PART[bluedog_Pioneer6_TopAntenna]:NEEDS[RemoteTech!SETIRebalance] // PIO6E-PWD Antenna
 {
         !MODULE[ModuleDataTransmitter] {}
 
@@ -680,7 +680,7 @@
         %MODULE[ModuleSPUPassive] {}
 }
 
-@PART[bluedog_Pioneer6_BottomAntenna]:NEEDS[RemoteTech] // PIO6E-SRE Antenna
+@PART[bluedog_Pioneer6_BottomAntenna]:NEEDS[RemoteTech!SETIRebalance] // PIO6E-SRE Antenna
 {
         !MODULE[ModuleDataTransmitter] {}
 

--- a/Gamedata/Bluedog_DB/Compatibility/SETIRebalance/Remotetech_antennas
+++ b/Gamedata/Bluedog_DB/Compatibility/SETIRebalance/Remotetech_antennas
@@ -1,0 +1,709 @@
+@PART[bluedog_dipole]:NEEDS[RemoteTech,SETIrebalance] //DP-75 Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 250000
+		%Mode1OmniRange = 5000000
+		%EnergyCost = 0.06
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_domeAntenna]:NEEDS[RemoteTech,SETIrebalance] //MSC Dome Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0DishRange = 0
+		%Mode1DishRange = 25000000000
+		%EnergyCost = 0.15
+		%DishAngle = 2
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 6
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_LOantenna]:NEEDS[RemoteTech,SETIrebalance] //A23 Omni Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 250000
+		%Mode1OmniRange = 2500000
+		%EnergyCost = 0.05
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_LOdish]:NEEDS[RemoteTech,SETIrebalance] //A66 Communications Dish
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0DishRange = 0
+		%Mode1DishRange = 12000000
+		%EnergyCost = 0.1
+		%DishAngle = 15
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 6
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_rangerDish]:NEEDS[RemoteTech,SETIrebalance] //OVBR-1 Communications Dish
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0DishRange = 0
+		%Mode1DishRange = 50000000
+		%EnergyCost = 0.09
+		%DishAngle = 20
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 6
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_telstar]:NEEDS[RemoteTech,SETIrebalance] //F21 Helical Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 250000
+		%Mode1OmniRange = 3000000
+		%EnergyCost = 0.05
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_mariner2Antenna]:NEEDS[RemoteTech,SETIrebalance] //A27-C Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 250000
+		%Mode1OmniRange = 10000000
+		%EnergyCost = 0.2
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_mariner4Antenna]:NEEDS[RemoteTech,SETIrebalance] //N100 Omni Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 250000
+		%Mode1OmniRange = 12000000
+		%EnergyCost = 0.22
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_mariner4Dish]:NEEDS[RemoteTech,SETIrebalance] //J15-D Communications Dish
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0DishRange = 0
+		%Mode1DishRange = 35000000000
+		%EnergyCost = 0.18
+		%DishAngle = 1.5
+		%DeployFxModules = 0
+
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 16
+			%PacketResourceCost = 15.0
+		}
+
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_scimitar]:NEEDS[RemoteTech,SETIrebalance] //WPT Scimitar Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0DishRange = 0
+		%Mode1DishRange = 12000000
+		%EnergyCost = 0.09
+		%DishAngle = 150
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 4
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_simpleAntenna]:NEEDS[RemoteTech,SETIrebalance] //KD2 Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 250000
+		%Mode1OmniRange = 2000000
+		%EnergyCost = 0.05
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_agenaAntenna]:NEEDS[RemoteTech,SETIrebalance] //Belle B81 Command Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 250000
+		%Mode1OmniRange = 8000000
+		%EnergyCost = 0.04
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_solarAntenna]:NEEDS[RemoteTech,SETIrebalance] //M17 Solar Antenna
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 0
+		%Mode1OmniRange = 1000000
+		%EnergyCost = 0.033
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_mercuryScience]:NEEDS[RemoteTech,SETIrebalance] //Hermes SAM
+{
+	!MODULE[ModuleDataTransmitter] {}
+	
+	@MODULE[ModuleScienceExperiment]
+	{
+		!FxModules = delete
+	}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 250000
+		%Mode1OmniRange = 1000000
+		%EnergyCost = 0.033
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_MOL_rackDish]:NEEDS[RemoteTech,SETIrebalance] //MOS-MCL Communications Dish
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0DishRange = 0
+		%Mode1DishRange = 2500000
+		%EnergyCost = 0.0125
+		%DishAngle = 90
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 60
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Apollo_Block2_HGA]:NEEDS[RemoteTech,SETIrebalance] //Kane-11-CDA 
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0DishRange = 0
+		%Mode1DishRange = 50000000
+		%EnergyCost = 0.15
+		%DishAngle = 20
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.2
+			%PacketSize = 5
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_malhenaSolar]:NEEDS[RemoteTech,SETIrebalance] //Leo-010SM
+{
+	!MODULE[ModuleDataTransmitter] {}
+
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 250000
+		%Mode1OmniRange = 2000000
+		%EnergyCost = 0.05
+		%MaxQ = 6000
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.35
+			%PacketSize = 2
+			%PacketResourceCost = 12.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Apollo_Block3_HGA]:NEEDS[RemoteTech,SETIrebalance] //Kane-11-CDA
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0DishRange = 0
+                %Mode1DishRange = 12500000 // 0.25 range, 0.25 dishes
+                %EnergyCost = 0.1
+                %DishAngle = 10 // 10 versus 20 orig.
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.2
+                        %PacketSize = 5
+                        %PacketResourceCost = 15.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Apollo_Block5_HGA]:NEEDS[RemoteTech,SETIrebalance] //Kane-11-CDA
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0DishRange = 0
+                %Mode1DishRange = 25000000 // 0.50 range, 0.50 dishes
+                %EnergyCost = 0.12
+                %DishAngle = 15 // 15 versus 20 orig.
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.2
+                        %PacketSize = 5
+                        %PacketResourceCost = 15.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_LEM_Ascent_Antenna1]:NEEDS[RemoteTech,SETIrebalance] //MEM-WCT Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 0
+                %Mode1OmniRange = 15000
+                %EnergyCost = 0.01 // Low cost for low range?
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.35
+                        %PacketSize = 2
+                        %PacketResourceCost = 12.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_LEM_Ascent_Antenna2]:NEEDS[RemoteTech,SETIrebalance] //MEM-SSC Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 0
+                %Mode1OmniRange = 150000
+                %EnergyCost = 0.03
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.35
+                        %PacketSize = 2
+                        %PacketResourceCost = 12.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Skylab_DisconeAntenna]:NEEDS[RemoteTech,SETIrebalance] //Hokulani-DCA Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 50000
+                %Mode1OmniRange = 2000000
+                %EnergyCost = 0.05
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.35
+                        %PacketSize = 2
+                        %PacketResourceCost = 12.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Saturn_VFB_Dish]:NEEDS[RemoteTech,SETIrebalance] // Sarnus-BFBMa(76) Dish
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0DishRange = 0
+                %Mode1DishRange = 3.84E+10 // Specs borrowed from Coatl Verona Dish
+                %EnergyCost = 0.3
+                %DishAngle = 7.5
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.45
+                        %PacketSize = 4
+                        %PacketResourceCost = 20.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Pioneer6_TopAntenna]:NEEDS[RemoteTech,SETIrebalance] // PIO6E-PWD Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 80000 // Specs borrowed from Coatl CA-A07 config
+                %Mode1OmniRange = 2800000
+                %EnergyCost = 0.06
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.65
+                        %PacketSize = 2
+                        %PacketResourceCost = 10.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_Pioneer6_BottomAntenna]:NEEDS[RemoteTech,SETIrebalance] // PIO6E-SRE Antenna
+{
+        !MODULE[ModuleDataTransmitter] {}
+
+        @MODULE[ModuleAnimateGeneric]
+        {
+                %allowManualControl = false
+        }
+
+        %MODULE[ModuleRTAntenna]
+        {
+                %Mode0OmniRange = 40000 // Specs a total guess
+                %Mode1OmniRange = 1400000
+                %EnergyCost = 0.02
+                %MaxQ = 6000
+                %DeployFxModules = 0
+
+                %TRANSMITTER
+                {
+                        %PacketInterval = 0.65
+                        %PacketSize = 2
+                        %PacketResourceCost = 10.0
+                }
+        }
+
+        %MODULE[ModuleSPUPassive] {}
+}


### PR DESCRIPTION
Harmonizes energy consumption between BDD RemoteTech antennas and SETIRebalance RemoteTech antennas. 
Edits current RemoteTech patch parameters, from NEEDS:[RemoteTech] to NEEDS:[RemoteTech!SETIRebalance]. 
Adds a duplicate of the original RemoteTech patch, edited with SETIRebalance-ish numbers to its own folder, with the parameters NEEDS:[RemoteTech,SETIRebalance]. 
Adds a RealFuels entry to the Saturn files for the J2A2. 
All verified working ingame. 