### PR TITLE
Rebalance some outlying antenna values (MOS-MCL, A27-C)

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Antennas/bluedog_mariner2Antenna.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Antennas/bluedog_mariner2Antenna.cfg
@@ -35,9 +35,9 @@ MODEL
 	{
 		name = ModuleDataTransmitter
 		antennaType = DIRECT
-		packetInterval = 19.2
-		packetSize = 2
-		packetResourceCost = 12.0
+		packetInterval = 1.2
+		packetSize = 0.3
+		packetResourceCost = 2.5
 		requiredResource = ElectricCharge
 		//DeployFxModules = 0
 		antennaPower = 16000000

--- a/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_MOL_rackDish.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_MOL_rackDish.cfg
@@ -46,9 +46,9 @@ MODEL
 	{
 		name = ModuleDataTransmitter
 		antennaType = DIRECT
-		packetInterval = 0.1
-		packetSize = 2
-		packetResourceCost = 12.0
+		packetInterval = 0.25
+		packetSize = 4
+		packetResourceCost = 20.0
 		requiredResource = ElectricCharge
 		DeployFxModules = 0
 		antennaPower = 25000000


### PR DESCRIPTION
These are the two big outliers in the BDB pack.  One had too low of a packet interval, the other had too high of a packet interval.  The antennas with a 4.8 sec interval are marginal, but I left them alone for now.

#### MOS-MCL Communications Dish (bluedog_MOL_rackDish.cfg)

Puts this more in-line with the Apollo Kane-11 series

- EC/s: 120.00 -> 80.00
- Mit/s: 20.00 -> 16.00
- EC/Mit: 6.00 -> 5.00

#### A27-C Antenna (bluedog_mariner2Antenna)

In my opinion, 19 seconds was way too long of a packet interval.  Makes the user think that nothing is happening because they don't get quick enough feedback.  This keeps the slow rate of transmission (still a bit faster) and puts it in line with others for energy efficiency.

- EC/s: 0.63 -> 2.08
- Mit/s: 0.10 -> 0.25
- EC/Mit: 6.00 -> 8.33

---

Original values:

![image](https://user-images.githubusercontent.com/11258412/42463350-e65c3100-8373-11e8-92a6-901463af2b51.png)

Taken from (where I compare 190+ antennas):

https://docs.google.com/spreadsheets/d/1yj08CJX458ZbHOsLgVckEtqvHUj5KkP1En-R1kLIYyw/edit#gid=1416012780