### PR TITLE
Add science definitions for low space science using the cameras

### DIFF
--- a/Gamedata/Bluedog_DB/Resources/ScienceDefs.cfg
+++ b/Gamedata/Bluedog_DB/Resources/ScienceDefs.cfg
@@ -362,6 +362,21 @@ EXPERIMENT_DEFINITION
 	MunSrfLandedSouthwestCrater = The Southwest Crater was also formed around the same time as the other colossal sized craters on the surface.  Photographic evidence is helping to answer many of the questions surrounding this violent time of the Mun's history.
 	MunSrfLandedTwinCraters = Formed when two bodies in orbit around each other collided with the Mun, photos of the Twin Craters have shown this region to be younger than originally thought				
 	MunSrfLanded = The ground is very grey. Around you, there are slopes and mountains.
+			MunInSpaceLowMidlands = The surface is littered with small impact craters. The flat areas here may have been formed by volcanic activity. 
+			MunInSpaceLowMidlandCraters = You wonder how big of an asteroid is needed to make craters this wide, before realizing there are far larger craters on the Mun.
+			MunInSpaceLowHighlands = The highlands are lighter in appearence, 
+			MunInSpaceLowHighlandCraters = Some of these craters look to be far older than the ones in the Mun’s midlands
+			MunInSpaceLowCanyons = The steep walls of the canyons might make landing difficult. 
+			MunInSpaceLowNorthernBasin = The basin was likely formed by volcanic activity. 
+			MunInSpaceLowEastCrater = One of the most prominent landmarks on the Mun when viewed from the surface of Kerbin, Kerbals have spent millennia guessing what might have created it.
+			MunInSpaceLowNorthwestCrater = Just another impact crater, located in the northwest.
+			MunInSpaceLowSouthwestCrater = Just another impact crater, located in the southwest.
+			MunInSpaceLowFarsideCrater = You reflect on how you’re the first kerbal to see this part of the Mun.
+			MunInSpaceLowTwinCraters = Despite their similarity, these craters may have been created millions of years apart
+			MunInSpaceLowEastFarsideCrater = The crater is nicely framed by Kerbin rising over the horizon.
+			MunInSpaceLowPolarCrater = Unlike the rest of the Mun’s craters, this one is far from the equator. 
+			MunInSpaceLowPoles = Not much different from the rest of the mun, except that some parts of the polar region receive sunlight almost year round
+			MunInSpaceLowPolarLowlands = Lower areas near the poles might contain water ice where craters are kept in eternal darkness. Or not. Its not like you can see anything in them.
 			MunInSpaceLow = Closer to the moon now, you see that craters have ravaged the surface. Even the plains are unforgiven, which makes you infer that time has taken its toll on the Mun's surface... 
 				MunInSpaceHigh = The Mun appears to be very cratered while the lowlands sit pristinely below all of the mountains. 
 

--- a/Gamedata/Bluedog_DB/Resources/ScienceDefs.cfg
+++ b/Gamedata/Bluedog_DB/Resources/ScienceDefs.cfg
@@ -332,7 +332,18 @@ EXPERIMENT_DEFINITION
 	KerbinSrfLandedShores = The photos of the shores you have taken have recently been licensed by a travel company to create brochures to bring tourists to the beach.
 	KerbinSrfLandedWater = While the ocean is beautiful and terrible to behold at times, today it is nearly smooth as glass and you capture reflected sunlight from the surface of the water at sunset creating a lovely image.
 	KerbinSrfLanded = Haven't you seen this before? 
-			KerbinInSpaceLow = Who knew the space agency would be spying on all these Krussians? 
+			KerbinInSpaceLowGrasslands = The grasslands make up most of Kerbin’s surface, and where most Kerbals live. The surface is covered by farms and the occasional city.
+			KerbinInSpaceLowShores = The water near shores have a lighter shade of blue where it gets shallower. If you could zoom in more you might be able to spot some kerbal a enjoying a day on the beach.
+			KerbinInSpaceLowMountains = Snow-capped peaks used to be one of the best destination for adventurous kerbals. At least before the invention of space travel.
+			KerbinInSpaceLowHighlands = The mountains blend into lower terrain with branching ridges. The hills are striped as the valleys cut through different layers of rock.
+			KerbinInSpaceLowDesert = The sands look flat compared to the rest of Kerbin’s terrain. There are some strange circles on the surface, which command tells you are farms.
+			KerbinInSpaceLowWater = The ocean’s surface is dotted with the wakes of ships traveling across Kerbin’s surface
+			KerbinInSPaceLowBadlands = The surface looks rocky and difficult to navigate. You confirm the badlands are in fact bad. 
+			KerbinInSpaceLowTundra = You spot some Krussian military bases in the snow. The government agency who gave you your assignment will be pleased.
+			KerbinInSpaceLowIceCaps = Sunlight reflecting off the snow overwhelms the camera.
+			KerbinInSpaceLowNorthernIceShelf = Public Outreach tells the public you spotted the Gift Kracken, but you didn’t really. 
+			KerbinInSpaceLowSouthernIceShelf = There isn’t much here but a flat sheet of ice.  
+			KerbinInSpaceLow = Who knew the space agency would be spying on all these Krussians?
 					KerbinInSpaceHigh = There is something very familiar about all this water and land you see. 
 
 	MunSrfLandedCanyons = Image data of the canyons on the Mun shows it was geologically active at one point in time but no longer.


### PR DESCRIPTION
Allows for unique science to be collected in low space for each biome, similar to EVA reports. You can now perform Keyhole/Lunar Orbiter missions to collect data about planets

currently only has text for Kerbin and Mun, other bodies will show the same generic message for each biome