### PR TITLE
Real Fuels fix for new Atlas, Centaur engines

### DIFF
--- a/BD_Extras (No Warranty)/RealFuels-Dev/RealFuels-Stockalike/BDB/RF_BDB_Atlas.cfg
+++ b/BD_Extras (No Warranty)/RealFuels-Dev/RealFuels-Stockalike/BDB/RF_BDB_Atlas.cfg
@@ -15,7 +15,7 @@
 	!RESOURCE[Oxidizer] {}
 }
 
-@PART[bluedog_atlasBooster]:NEEDS[RealFuels,!RealismOverhaul]
+@PART[bluedog_Atlas_LR89]:NEEDS[RealFuels,!RealismOverhaul]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -127,7 +127,7 @@
 	!MODULE[PartStatsUpgradeModule] {}
 }
 
-@PART[bluedog_atlasSustainer]:NEEDS[RealFuels,!RealismOverhaul]
+@PART[bluedog_Atlas_LR105]:NEEDS[RealFuels,!RealismOverhaul]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -238,7 +238,7 @@
 	}
 }
 
-@PART[bluedog_atlasVernier,bluedog_stackVernier]:NEEDS[RealFuels,!RealismOverhaul]
+@PART[bluedog_Atlas_LR101_Radial,bluedog_Atlas_LR101_Inline]:NEEDS[RealFuels,!RealismOverhaul]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/BD_Extras (No Warranty)/RealFuels-Dev/RealFuels-Stockalike/BDB/RF_BDB_Centaur.cfg
+++ b/BD_Extras (No Warranty)/RealFuels-Dev/RealFuels-Stockalike/BDB/RF_BDB_Centaur.cfg
@@ -172,6 +172,40 @@
 				key = 1 20
 			}
 		}
+	}
+}
+
+@PART[bluedog_Centaur_RL10A41]:NEEDS[RealFuels,!RealismOverhaul]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		ignitions = 5
+		ullage = True
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 16.104
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 5.5
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 425
+			@key,1 = 1 20
+		}
+		
+		!UPGRADES {}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesRF
+		configuration = RL-10A1
+		
 		CONFIG
 		{
 			name = RL-10A4
@@ -199,11 +233,9 @@
 			}
 		}
 	}
-	
-	!MODULE[PartStatsUpgradeModule] {}
 }
 
-@PART[bluedog_Centaur_RL10B]:NEEDS[RealFuels,!RealismOverhaul]
+@PART[bluedog_Centaur_RL10B2]:NEEDS[RealFuels,!RealismOverhaul]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Delta_AJ10.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Delta_AJ10.cfg
@@ -11,8 +11,8 @@
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0
-        flarePosition = 0,0,1.1
-        plumePosition = 0,0,1
+        flarePosition = 0,0,0.5
+        plumePosition = 0,0,0.55
         fixedScale = 0.77
         energy = 1
         speed = 1


### PR DESCRIPTION
Fixed names for Atlas booster/sustainer/vernier engines, added RL-10A-4-1