### PR TITLE
wet workshops can have snacks now

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Snacks/SkylabWetSnacks.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Snacks/SkylabWetSnacks.cfg
@@ -1,0 +1,12 @@
+@B9_TANK_TYPE[bdbSkylabLab]:NEEDS[B9PartSwitch,Snacks] {
+	RESOURCE
+	{
+		name = Snacks
+		unitsPerVolume = 0.11 //1200/11300
+	}
+	RESOURCE
+	{
+		name = Soil
+		unitsPerVolume = 0.05 //600/11300
+	}
+}


### PR DESCRIPTION
Ok after months, I just added a independent snacks folder config that changes the tank type for the wet workshops.  Now they have snacks when you change them to the labs.  I love the wet workshops by the way.