### PR TITLE
Add OGO probe core to RT; fix typo in OGO cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Probes.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Probes.cfg
@@ -564,21 +564,42 @@
 
 @PART[bluedog_DeltaK_ShortTank]:NEEDS[RemoteTech] // The tanks are slowing gaining awareness and will soon slay us all.
 {
-        %MODULE[ModuleSPU] {}
+    %MODULE[ModuleSPU] {}
 
-        %MODULE[ModuleRTAntennaPassive]
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
         {
-                %TechRequired = unmannedTech
-                %OmniRange = 300000
-
-                %TRANSMITTER
-                {
-                        %PacketInterval = 0.3
-                        %PacketSize = 2
-                        %PacketResourceCost = 15.0
-                }
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
         }
-		
-		%MODULE[ModuleSPUPassive] {}
+    }
+
+    %MODULE[ModuleSPUPassive] {}
+}
+
+@PART[bluedog_OGO_Core]:NEEDS[RemoteTech] // HLR-OGO "Sansisco" Probe Core
+{
+
+    %MODULE[ModuleSPU] {}
+
+    %MODULE[ModuleRTAntennaPassive]
+    {
+        %TechRequired = unmannedTech
+        %OmniRange = 300000
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+
+    %MODULE[ModuleSPUPassive] {}
 }
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_OGO_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_OGO_Core.cfg
@@ -18,7 +18,7 @@ MODEL
 	subcategory = 0
 	title = HLR-OGO "Sansisco" Probe Core
 	manufacturer = Bluedog Design Bureau
-	description = Medium sized, rectangular probe bus for scientific and commericial satellites, originally design for our geophysical research satellite series. Includes the standard loadout of control processors, batteries, and other essential equipment.
+	description = Medium sized, rectangular probe bus for scientific and commercial satellites, originally design for our geophysical research satellite series. Includes the standard loadout of control processors, batteries, and other essential equipment.
 	attachRules = 1,0,1,1,0
 	mass = 0.2
 	dragModelType = default


### PR DESCRIPTION
Found these during my last session. Simple adjustments, adding the OGO probe core to the RT configs. Separately, also fixes a minor typo in the OGO probe core config.