### PR TITLE
Fix MalhenaSM Life Support Description

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/USI-LS/USI-LS.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/USI-LS/USI-LS.cfg
@@ -107,8 +107,13 @@
 // Item description says LEO MSM60 Service module is filled with Fuel, Monoprop etc AND LS Supplies.
 // Therefore, following patch adds 325 supplies, enough for 2 Kerbals to survive 15 days without recycling.
 
+@PART[bluedog_Gemini_MalhenaSM]:NEEDS[!USILifeSupport]
+{
+	@description ^= : and batteries:, batteries and life support supplies:
+}
 @PART[bluedog_Gemini_MalhenaSM]:NEEDS[USILifeSupport]
 {
+	@description ^= : and batteries:, batteries and life support supplies:
 		RESOURCE
 		{
 			name = Supplies

--- a/Gamedata/Bluedog_DB/Compatibility/USI-LS/USI-LS.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/USI-LS/USI-LS.cfg
@@ -107,10 +107,6 @@
 // Item description says LEO MSM60 Service module is filled with Fuel, Monoprop etc AND LS Supplies.
 // Therefore, following patch adds 325 supplies, enough for 2 Kerbals to survive 15 days without recycling.
 
-@PART[bluedog_Gemini_MalhenaSM]:NEEDS[!USILifeSupport]
-{
-	@description ^= : and batteries:, batteries and life support supplies:
-}
 @PART[bluedog_Gemini_MalhenaSM]:NEEDS[USILifeSupport]
 {
 	@description ^= : and batteries:, batteries and life support supplies:

--- a/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_MalhenaSM.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_MalhenaSM.cfg
@@ -20,7 +20,7 @@ MODEL
 	subcategory  = 0
 	title        = Leo-MSM-650 Service Module Tank
 	manufacturer = Bluedog Design Bureau
-	description  = 1.5m service module tank, filled to the brim with LFO, monopropellant, batteries, and life support supplies. 
+	description  = 1.5m service module tank, filled to the brim with LFO, monopropellant and batteries. 
 	mass = 1.5
 	dragModelType  = default
 	maximum_drag   = 0.20


### PR DESCRIPTION
OK, last one for tonight. The part description lists off fuel, batteries and life support, but this is only true with the USI-LS compatibility patch, the other types of life support don't handle it. 

This fixes the description in the base part, and re-sets it in the USI patch. Ideally all patches should handle it but I didn't want to get into that at the moment, and this will fix the main issue at least.