### PR TITLE
Typo fix in DeltaP_FairingRing.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Delta/bluedog_DeltaP_FairingRing.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Delta/bluedog_DeltaP_FairingRing.cfg
@@ -20,7 +20,7 @@ MODEL
 	subcategory = 0
 	title = Daleth-P Fairing Adapter
 	manufacturer = Bluedog Design Bureau
-	description = This 1.5m fairing base ring allows you to "hang" a 9.375m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. We're working on a custom stage for it, but for now you could just reuse leftover Alphastar tankage and Sina lander engines...
+	description = This 1.5m fairing base ring allows you to "hang" a 0.9375m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. We're working on a custom stage for it, but for now you could just reuse leftover Alphastar tankage and Sina lander engines...
 	attachRules = 1,0,1,1,0
 	mass = 0.095
 	dragModelType = default


### PR DESCRIPTION
Pretty sure this is a simple typo in the description.