### PR TITLE
Add monoPropellant option to cargo containers

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/B9PartSwitch/B9PartSwitchTanks.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/B9PartSwitch/B9PartSwitchTanks.cfg
@@ -51,6 +51,17 @@
 			@addedCost *= -1
 			percentFilled = #$../../fuelPctFill$
 		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			tankType = bdbMonoProp
+			//allowSwitchInFlight = True
+			addedMass = #$../../tank_mass$
+			@addedMass *= -1
+			addedCost = #$../../tank_plus_fuel_cost$
+			@addedCost *= -1
+			percentFilled = #$../../fuelPctFill$
+		}
 	}
 }
 


### PR DESCRIPTION
as per Pappystein request at the forums, the cargo containers could have a monopropellant setting.
https://forum.kerbalspaceprogram.com/index.php?/topic/122020-16x-bluedog-design-bureau-stockalike-saturn-apollo-and-more-v152-%D0%B1%D1%80%D1%83%D0%BD%D0%BE-8feb2019/&page=500