### PR TITLE
Fix B9PartSwitch warnings

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Titan/Old/bluedog_LR87_SingleChamberB.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Titan/Old/bluedog_LR87_SingleChamberB.cfg
@@ -145,7 +145,7 @@ MODEL
 		SUBTYPE
 		{
 			name = None
-			transform = BareEngine
+			transform = BareEngine_Store1
 		}
 	}
 }

--- a/Gamedata/Bluedog_DB/Parts/Titan/Old/bluedog_SMRU.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Titan/Old/bluedog_SMRU.cfg
@@ -379,23 +379,4 @@ MODEL
 		falloff = 2
 		thrustTransformName = thrustTransform
 	}
-	
-	MODULE
-	{
-		name = ModuleB9PartSwitch
-		moduleID = meshSwitch
-		switcherDescription = Hydraulic Tanks
-		affectDragCubes = False
-		affectFARVoxels = False
-		SUBTYPE
-		{
-			name = Radial
-			transform = Radial
-		}
-		SUBTYPE
-		{
-			name = Inline
-			transform = Inline
-		}
-	}
 }

--- a/Gamedata/Bluedog_DB/Parts/Titan/bluedog_LR91_11.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Titan/bluedog_LR91_11.cfg
@@ -274,7 +274,7 @@ MODEL
 		SUBTYPE
 		{
 			name = Titan 2
-			transform = Titan2
+			transform = Titan3
 		}
 		
 		SUBTYPE


### PR DESCRIPTION
* New LR-91-11 has a transform named wrong (subtype is probably named wrong too but not going to question that)
* Old single chamber LR-87 has a transform named wrong
* Old SRMU has a ModuleB9PartSwitch that switches stuff it doesn't have (hydraulic tanks)

All of this will complain to the user in the next version of B9PartSwitch