### PR TITLE
Add RescuePodValidator compatibility

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/RescuePodFix.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RescuePodFix.cfg
@@ -3,6 +3,7 @@
 	// Apollo
 	part = bluedog_Apollo_Block2_Capsule
 	part = bluedog_Apollo_Block3_Capsule
+	part = bluedog_LEM_Ascent_Cockpit
 	
 	// Gemini
 	part = bluedog_Gemini_Crew_A
@@ -11,13 +12,12 @@
 	
 	// MOL
 	part = bluedog_MOL_Airlock
+	part = bluedog_MOL_Lab
 	
 	// Mercury
 	part = bluedog_mercuryPod
 	
 	// Skylab
 	part = bluedog_Skylab_Airlock
-	
-	//Spacelab
 	part = bluedog_Spacelab_Airlock
 }

--- a/Gamedata/Bluedog_DB/Compatibility/RescuePodFix.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RescuePodFix.cfg
@@ -1,4 +1,4 @@
-@RESCUE_POD_TYPES:NEEDS[Bluedog_DB,KSPRescuePodFix]
+@RESCUE_POD_TYPES:NEEDS[KSPRescuePodFix]
 {
 	// Apollo
 	part = bluedog_Apollo_Block2_Capsule
@@ -7,7 +7,6 @@
 	
 	// Gemini
 	part = bluedog_Gemini_Crew_A
-	part = bluedog_Gemini_Crew_B
 	part = bluedog_Gemini_LanderCan
 	
 	// MOL

--- a/Gamedata/Bluedog_DB/Compatibility/RescuePodFix.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RescuePodFix.cfg
@@ -1,12 +1,23 @@
 @RESCUE_POD_TYPES:NEEDS[Bluedog_DB,KSPRescuePodFix]
 {
+	// Apollo
 	part = bluedog_Apollo_Block2_Capsule
 	part = bluedog_Apollo_Block3_Capsule
+	
+	// Gemini
 	part = bluedog_Gemini_Crew_A
 	part = bluedog_Gemini_Crew_B
 	part = bluedog_Gemini_LanderCan
+	
+	// MOL
 	part = bluedog_MOL_Airlock
+	
+	// Mercury
 	part = bluedog_mercuryPod
+	
+	// Skylab
 	part = bluedog_Skylab_Airlock
+	
+	//Spacelab
 	part = bluedog_Spacelab_Airlock
 }

--- a/Gamedata/Bluedog_DB/Compatibility/RescuePodFix.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RescuePodFix.cfg
@@ -1,0 +1,12 @@
+@RESCUE_POD_TYPES:NEEDS[Bluedog_DB,KSPRescuePodFix]
+{
+	part = bluedog_Apollo_Block2_Capsule
+	part = bluedog_Apollo_Block3_Capsule
+	part = bluedog_Gemini_Crew_A
+	part = bluedog_Gemini_Crew_B
+	part = bluedog_Gemini_LanderCan
+	part = bluedog_MOL_Airlock
+	part = bluedog_mercuryPod
+	part = bluedog_Skylab_Airlock
+	part = bluedog_Spacelab_Airlock
+}


### PR DESCRIPTION
Allows RescuePodValidator to use BDB parts.
Includes:

- Kane 11-3
- Kane 11-5
- Sina-MEM-ASC Cockpit
- Leo-M-63E "Vinci"
- Leo-LK217 Miniature Lander Can
- MOS-AS "Adventure" Airlock
- MOS-LS "Mossy" Laboratory
- Hermes M-PRC Capsule
- Hokulani-ALM Airlock
- Hokulani-EALM Expansion Airlock
