### PR TITLE
New prefab for lander engines

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Apollo.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Apollo.cfg
@@ -23,108 +23,68 @@
         blazeScale = 1.5
     }
 }
-@PART[bluedog_Apollo_Block2_ServiceEngine]:HAS[@PLUME[BDB_HypergolicUpper_White]]:AFTER[zRealPlume]
-{
-    @EFFECTS
-    {
-        @BDB_HypergolicUpper_White
-        {
-            @AUDIO
-            {
-                vol = #$volume,1[1, ]$
-                @vol *= 3
-                @volume,1 = #1.0 $vol$
-                !vol = DEL
-            }
-        }
-    }
-}
 
 //Block III SPS
 @PART[bluedog_Apollo_Block3_ServiceEngine]:NEEDS[zRealPlume,SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-      @name = ModuleEnginesFX
-      %powerEffectName = BDB_HypergolicUpperYellow
-    }
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesFX
+		%powerEffectName = BDB_Hypergolic_Lander
+	}
     PLUME
     {
-        name = BDB_HypergolicUpperYellow
+        name = BDB_Hypergolic_Lander
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0
-				energy = 1
-        speed = 1
+
+        energy = 0.5
+        speed = 0.5
 
         flarePosition = 0,0,0.3
-				flareScale = 0.2
+        flareScale = 0.15
 
-        FumePosition = 0,0,0.6
-				FumeScale = 0.7
+        plumePosition = 0,0,0.5
+        plumeScale = 0.8
 
-				streamPosition = 0,0,0.5
-				streamScale = 0.6
-	}
-}
-@PART[bluedog_Apollo_Block3_ServiceEngine]:HAS[@PLUME[BDB_HypergolicUpperYellow]]:AFTER[zRealPlume]
-{
-    @EFFECTS
-    {
-        @BDB_HypergolicUpperYellow
-        {
-            @AUDIO
-            {
-                vol = #$volume,1[1, ]$
-                @vol *= 10
-                @volume,1 = #1.0 $vol$
-                !vol = DEL
-            }
-        }
+        fumePosition = 0,0,0.6
+        fumeScale = 0.6
+
+        blazePosition = 0,0,0.5
+        blazeScale = 0.5
     }
 }
 
 //Block V SPS
 @PART[bluedog_Apollo_Block5_ServiceEngine]:NEEDS[zRealPlume,SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-      @name = ModuleEnginesFX
-      %powerEffectName = BDB_HypergolicUpperYellow
-    }
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesFX
+		%powerEffectName = BDB_Hypergolic_Lander
+	}
     PLUME
     {
-        name = BDB_HypergolicUpperYellow
+        name = BDB_Hypergolic_Lander
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0
-				energy = 1
-        speed = 1
+
+        energy = 0.5
+        speed = 0.5
 
         flarePosition = 0,0,0.6
-				flareScale = 0.25
+        flareScale = 0.25
 
-        FumePosition = 0,0,1
-				FumeScale = 1.2
+        fumePosition = 0,0,1
+        fumeScale = 1
 
-				streamPosition = 0,0,0.9
-				streamScale = 0.8
-	}
-}
-@PART[bluedog_Apollo_Block5_ServiceEngine]:HAS[@PLUME[BDB_HypergolicUpperYellow]]:AFTER[zRealPlume]
-{
-    @EFFECTS
-    {
-        @BDB_HypergolicUpperYellow
-        {
-            @AUDIO
-            {
-                vol = #$volume,1[1, ]$
-                @vol *= 10
-                @volume,1 = #1.0 $vol$
-                !vol = DEL
-            }
-        }
+        plumePosition = 0,0,0.7
+        plumeScale = 1.2
+
+        blazePosition = 0,0,0.7
+        blazeScale = 0.7
     }
 }
 

--- a/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Gemini.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Gemini.cfg
@@ -1,0 +1,31 @@
+//Ascent engine
+@PART[bluedog_Gemini_Lander_Engine]:NEEDS[zRealPlume,SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesFX
+		%powerEffectName = BDB_Hypergolic_Lander
+	}
+    PLUME
+    {
+        name = BDB_Hypergolic_Lander
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+
+        energy = 0.5
+        speed = 0.5
+
+        flarePosition = 0,0,-0.1
+        flareScale = 0.08
+
+        plumePosition = 0,0,0.1
+        plumeScale = 0.4
+
+        fumePosition = 0,0,0.1
+        fumeScale = 0.4
+
+        blazePosition = 0,0,0
+        blazeScale = 0.4
+    }
+}

--- a/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_LEM.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_LEM.cfg
@@ -1,87 +1,63 @@
 //Ascent engine
 @PART[bluedog_LEM_Ascent_Engine]:NEEDS[zRealPlume,SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-      @name = ModuleEnginesFX
-      %powerEffectName = BDB_HypergolicUpperYellow
-    }
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesFX
+		%powerEffectName = BDB_Hypergolic_Lander
+	}
     PLUME
     {
-        name = BDB_HypergolicUpperYellow
+        name = BDB_Hypergolic_Lander
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0
-				energy = 1
-        speed = 1
+
+        energy = 0.5
+        speed = 0.5
 
         flarePosition = 0,0,0
-				flareScale = 0.2
+        flareScale = 0.15
 
-        FumePosition = 0,0,0.3
-				FumeScale = 0.7
+        plumePosition = 0,0,0.2
+        plumeScale = 0.8
 
-				streamPosition = 0,0,0.25
-				streamScale = 0.6
-	}
-}
-@PART[bluedog_LEM_Ascent_Engine]:HAS[@PLUME[BDB_HypergolicUpperYellow]]:AFTER[zRealPlume]
-{
-    @EFFECTS
-    {
-        @BDB_HypergolicUpperYellow
-        {
-            @AUDIO
-            {
-                vol = #$volume,1[1, ]$
-                @vol *= 12
-                @volume,1 = #1.0 $vol$
-                !vol = DEL
-            }
-        }
+        fumePosition = 0,0,0.3
+        fumeScale = 0.6
+
+        blazePosition = 0,0,0.2
+        blazeScale = 0.5
     }
 }
 
 //Descent Engine
 @PART[bluedog_LEM_Descent_Engine]:NEEDS[zRealPlume,SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-      @name = ModuleEnginesFX
-      %powerEffectName = BDB_HypergolicUpperYellow
-    }
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesFX
+		%powerEffectName = BDB_Hypergolic_Lander
+	}
     PLUME
     {
-        name = BDB_HypergolicUpperYellow
+        name = BDB_Hypergolic_Lander
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0
-				energy = 1
-        speed = 1
+
+        energy = 0.5
+        speed = 0.5
 
         flarePosition = 0,0,0.6
-				flareScale = 0.25
+        flareScale = 0.25
 
-        FumePosition = 0,0,1
-				FumeScale = 1.2
+        fumePosition = 0,0,1
+        fumeScale = 1
 
-				streamPosition = 0,0,0.9
-				streamScale = 0.8
-	}
-}
-@PART[bluedog_LEM_Descent_Engine]:HAS[@PLUME[BDB_HypergolicUpperYellow]]:AFTER[zRealPlume]
-{
-    @EFFECTS
-    {
-        @BDB_HypergolicUpperYellow
-        {
-            @AUDIO
-            {
-                vol = #$volume,1[1, ]$
-                @vol *= 12
-                @volume,1 = #1.0 $vol$
-                !vol = DEL
-            }
-        }
+        plumePosition = 0,0,0.7
+        plumeScale = 1.2
+
+        blazePosition = 0,0,0.7
+        blazeScale = 0.7
     }
 }

--- a/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Prefabs/BDB_HypergolicLander.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Prefabs/BDB_HypergolicLander.cfg
@@ -1,0 +1,301 @@
+// Prefab plume for hypergolic lander engines
+////////Refer to BDB_Plume_Keys.cfg for addtional documentation on density and power keys//////
+
+@PART[*]:HAS[@PLUME[BDB_Hypergolic_Lander]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+{
+  %EFFECTS
+    {
+      %BDB_Hypergolic_Lander
+        {
+            MODEL_MULTI_SHURIKEN_PERSIST
+            {
+                //Get the inputs from the other config.
+                transformName = #$../../../PLUME[BDB_Hypergolic_Lander]/transformName$
+                localRotation = #$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[0]$,$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[1]$,$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[2]$
+                localPosition = #$../../../PLUME[BDB_Hypergolic_Lander]/flarePosition[0]$,$../../../PLUME[BDB_Hypergolic_Lander]/flarePosition[1]$,$../../../PLUME[BDB_Hypergolic_Lander]/flarePosition[2]$
+                fixedScale    = #$../../../PLUME[BDB_Hypergolic_Lander]/flareScale$
+
+                name = flare
+                modelName = Bluedog_DB/FX/PlumeParty/Engines/BlueOrigin/hydroSLLamp
+                sizeClamp = 50
+                randomInitalVelocityOffsetMaxRadius = 0
+                decluster = true
+                emitOnUpdate = true
+
+                energy = 0.5
+                speed = 0.5
+                emissionMult  = 0.5
+
+                emission
+                {
+                power = #$@BDBPlume/BDBPowerKeys/startup$      0
+                power = #$@BDBPlume/BDBPowerKeys/flameout$     0.5
+                power = #$@BDBPlume/BDBPowerKeys/ignition$     0.6
+                power = #$@BDBPlume/BDBPowerKeys/deepThrottle$ 0.7
+                power = #$@BDBPlume/BDBPowerKeys/maxThrottle$  1.5
+                }
+            }
+            MODEL_MULTI_SHURIKEN_PERSIST
+            {
+                //Get the inputs from the other config.
+                transformName = #$../../../PLUME[BDB_Hypergolic_Lander]/transformName$
+                localRotation = #$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[0]$,$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[1]$,$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[2]$
+                localPosition = #$../../../PLUME[BDB_Hypergolic_Lander]/blazePosition[0]$,$../../../PLUME[BDB_Hypergolic_Lander]/blazePosition[1]$,$../../../PLUME[BDB_Hypergolic_Lander]/blazePosition[2]$
+                energy        = #$../../../PLUME[BDB_Hypergolic_Lander]/energy$
+                speed         = #$../../../PLUME[BDB_Hypergolic_Lander]/speed$
+                fixedScale    = #$../../../PLUME[BDB_Hypergolic_Lander]/blazeScale$
+                //
+                name = blaze
+                modelName = Bluedog_DB/FX/PlumeParty/Engines/BDB/TitanVacBlaze
+                sizeClamp = 50
+
+                randomInitalVelocityOffsetMaxRadius = 1
+                xyForce = 0
+                alphaMult = 0.35
+                emission
+                {
+                density = #$@BDBPlume/atmosphereKeys/key1$ 0
+                density = #$@BDBPlume/atmosphereKeys/key2$ 0
+                density = #$@BDBPlume/atmosphereKeys/key3$ 0
+                density = #$@BDBPlume/atmosphereKeys/key35$ 0.7
+                density = #$@BDBPlume/atmosphereKeys/key4$ 1
+                density = #$@BDBPlume/atmosphereKeys/key5$ 1
+
+                power = #$@BDBPlume/BDBPowerKeys/startup$       0
+                power = #$@BDBPlume/BDBPowerKeys/flameout$      0.5
+                power = #$@BDBPlume/BDBPowerKeys/ignition$      1
+                power = #$@BDBPlume/BDBPowerKeys/deepThrottle$  1.5
+                power = #$@BDBPlume/BDBPowerKeys/maxThrottle$   3
+                }
+                speed
+                {
+                density = #$@BDBPlume/atmosphereKeys/key2$ 4
+                density = #$@BDBPlume/atmosphereKeys/key3$ 4
+                density = #$@BDBPlume/atmosphereKeys/key4$ 3
+                density = #$@BDBPlume/atmosphereKeys/key5$ 2.5
+
+                power = #$@BDBPlume/BDBPowerKeys/startup$       0
+                power = #$@BDBPlume/BDBPowerKeys/flameout$      0.2
+                power = #$@BDBPlume/BDBPowerKeys/ignition$      0.3
+                power = #$@BDBPlume/BDBPowerKeys/deepThrottle$  0.5
+                power = #$@BDBPlume/BDBPowerKeys/maxThrottle$   1
+                }
+                logGrow
+                {
+                density = #$@BDBPlume/atmosphereKeys/key3$ 2
+                density = #$@BDBPlume/atmosphereKeys/key4$ 3
+                density = #$@BDBPlume/atmosphereKeys/key5$ 4
+                }
+                linGrow
+                {
+                density = #$@BDBPlume/atmosphereKeys/key3$ 2
+                density = #$@BDBPlume/atmosphereKeys/key4$ 3
+                density = #$@BDBPlume/atmosphereKeys/key5$ 4
+                }
+            }
+
+            MODEL_MULTI_SHURIKEN_PERSIST
+            {
+                //Get the inputs from the other config.
+                transformName = #$../../../PLUME[BDB_Hypergolic_Lander]/transformName$
+                localRotation = #$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[0]$,$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[1]$,$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[2]$
+                localPosition = #$../../../PLUME[BDB_Hypergolic_Lander]/fumePosition[0]$,$../../../PLUME[BDB_Hypergolic_Lander]/fumePosition[1]$,$../../../PLUME[BDB_Hypergolic_Lander]/fumePosition[2]$
+                fixedScale    = #$../../../PLUME[BDB_Hypergolic_Lander]/fumeScale$
+                energy        = #$../../../PLUME[BDB_Hypergolic_Lander]/energy$
+                speed         = #$../../../PLUME[BDB_Hypergolic_Lander]/speed$
+                emissionMult  = #$../../../PLUME[BDB_Hypergolic_Lander]/emissionMult$
+                //
+                name = Fume
+                modelName = Bluedog_DB/FX/PlumeParty/Engines/Hypergolic/VacFizzleFumeYellow
+                sizeClamp = 50
+                randomInitalVelocityOffsetMaxRadius = 0
+                randConeEmit = 0
+                decluster = true
+                emitOnUpdate = true
+                saturationMult = 0.5
+                emission
+                {
+                density = #$@BDBPlume/atmosphereKeys/key2$ 0
+                density = #$@BDBPlume/atmosphereKeys/key3$ 1
+                density = #$@BDBPlume/atmosphereKeys/key4$ 1
+                density = #$@BDBPlume/atmosphereKeys/key5$ 1
+
+                power = #$@BDBPlume/BDBPowerKeys/startup$      0
+                power = #$@BDBPlume/BDBPowerKeys/flameout$     0.5
+                power = #$@BDBPlume/BDBPowerKeys/ignition$     0.6
+                power = #$@BDBPlume/BDBPowerKeys/deepThrottle$ 1
+                power = #$@BDBPlume/BDBPowerKeys/maxThrottle$  1.5
+                }
+                speed
+                {
+                density = #$@BDBPlume/atmosphereKeys/key2$ 3
+                density = #$@BDBPlume/atmosphereKeys/key3$ 3
+                density = #$@BDBPlume/atmosphereKeys/key4$ 3
+                density = #$@BDBPlume/atmosphereKeys/key5$ 3
+
+                power = #$@BDBPlume/BDBPowerKeys/startup$      0.7
+                power = #$@BDBPlume/BDBPowerKeys/flameout$     0.7
+                power = #$@BDBPlume/BDBPowerKeys/ignition$     0.75
+                power = #$@BDBPlume/BDBPowerKeys/deepThrottle$ 0.8
+                power = #$@BDBPlume/BDBPowerKeys/maxThrottle$  1
+                }
+                energy
+                {
+                density = #$@BDBPlume/atmosphereKeys/key2$ 1
+                density = #$@BDBPlume/atmosphereKeys/key3$ 1
+                density = #$@BDBPlume/atmosphereKeys/key4$ 1
+                density = #$@BDBPlume/atmosphereKeys/key5$ 0.7
+                }
+                linGrow
+                {
+                density = #$@BDBPlume/atmosphereKeys/key2$ -2
+                density = #$@BDBPlume/atmosphereKeys/key3$ -1.3
+                density = #$@BDBPlume/atmosphereKeys/key4$ -1
+                density = #$@BDBPlume/atmosphereKeys/key5$ -0.5
+                }
+            }
+
+            MODEL_MULTI_SHURIKEN_PERSIST
+            {
+                //Get the inputs from the other config.
+                transformName = #$../../../PLUME[BDB_Hypergolic_Lander]/transformName$
+                localRotation = #$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[0]$,$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[1]$,$../../../PLUME[BDB_Hypergolic_Lander]/localRotation[2]$
+                localPosition = #$../../../PLUME[BDB_Hypergolic_Lander]/plumePosition[0]$,$../../../PLUME[BDB_Hypergolic_Lander]/plumePosition[1]$,$../../../PLUME[BDB_Hypergolic_Lander]/plumePosition[2]$
+                fixedScale    = #$../../../PLUME[BDB_Hypergolic_Lander]/plumeScale$
+                energy        = #$../../../PLUME[BDB_Hypergolic_Lander]/energy$
+                speed         = #$../../../PLUME[BDB_Hypergolic_Lander]/speed$
+                //emissionMult  = #$../../../PLUME[BDB_Hypergolic_Lander]/emissionMult$
+                //
+                name = SLstream
+                modelName = Bluedog_DB/FX/PlumeParty/Engines/BDB/TitanSLStream
+                fixedEmissions = false
+                sizeClamp = 50
+                alphaMult
+                {
+                density = #$@BDBPlume/atmosphereKeys/key3$ 1
+                density = #$@BDBPlume/atmosphereKeys/key5$ 0
+                }
+                xyForce
+                {
+                density = 1 0
+                density = 0 0
+                }
+                speed
+                {
+                density = 1.0 0.7
+                density = 0.0 0.7
+
+                power = #$@BDBPlume/BDBPowerKeys/ignition$      0.6
+                power = #$@BDBPlume/BDBPowerKeys/deepThrottle$  0.8
+                power = #$@BDBPlume/BDBPowerKeys/maxThrottle$   1.0
+
+                }
+                logGrow
+                {
+                density = #$@BDBPlume/atmosphereKeys/key0$ 0
+                density = #$@BDBPlume/atmosphereKeys/key1$ 1
+                density = #$@BDBPlume/atmosphereKeys/key2$ 3
+                density = #$@BDBPlume/atmosphereKeys/key3$ 15
+                density = #$@BDBPlume/atmosphereKeys/key4$ 15
+                density = #$@BDBPlume/atmosphereKeys/key5$ 30
+                }
+                zForce
+                {
+                density = #$@BDBPlume/atmosphereKeys/key0$ 1
+                density = #$@BDBPlume/atmosphereKeys/key1$ 1.01
+                density = #$@BDBPlume/atmosphereKeys/key2$ 1.02
+                density = #$@BDBPlume/atmosphereKeys/key3$ 1.03
+                density = #$@BDBPlume/atmosphereKeys/key4$ 1.04
+                density = #$@BDBPlume/atmosphereKeys/key5$ 1
+                }
+                linGrow
+                {
+                density = #$@BDBPlume/atmosphereKeys/key0$ 0
+                density = #$@BDBPlume/atmosphereKeys/key1$ 0
+                density = #$@BDBPlume/atmosphereKeys/key2$ 2
+                density = #$@BDBPlume/atmosphereKeys/key3$ 5
+                density = #$@BDBPlume/atmosphereKeys/key4$ 5
+                density = #$@BDBPlume/atmosphereKeys/key5$ 2
+                }
+                energy
+                {
+                density = #$@BDBPlume/atmosphereKeys/key0$ 1
+                density = #$@BDBPlume/atmosphereKeys/key3$ 1
+                density = #$@BDBPlume/atmosphereKeys/key4$ 1
+                density = #$@BDBPlume/atmosphereKeys/key5$ 0.5
+                }
+                emission
+                {
+                density = #$@BDBPlume/atmosphereKeys/key0$ 1
+                density = #$@BDBPlume/atmosphereKeys/key1$ 0.8
+                density = #$@BDBPlume/atmosphereKeys/key2$ 0.5
+                density = #$@BDBPlume/atmosphereKeys/key3$ 0.5
+                density = #$@BDBPlume/atmosphereKeys/key4$ 0.5
+                density = #$@BDBPlume/atmosphereKeys/key5$ 0.5
+                density = #$@BDBPlume/atmosphereKeys/key6$ 0
+
+                power = #$@BDBPlume/BDBPowerKeys/startup$       0
+                power = #$@BDBPlume/BDBPowerKeys/flameout$     0.4
+                power = #$@BDBPlume/BDBPowerKeys/ignition$     0.6
+                power = #$@BDBPlume/BDBPowerKeys/deepThrottle$ 0.9
+                power = #$@BDBPlume/BDBPowerKeys/maxThrottle$  1
+
+                }
+
+            }
+
+            AUDIO
+      			{
+      				channel = Ship
+      				clip = Bluedog_DB/Sounds/KW/sound_spsloop
+              volume = 0.0 0.0
+              volume = #$../../../PLUME[BDB_Hypergolic_Lander]/plumeScale$
+              @volume,1 ^= :^:1.0 :
+      				pitch = 0.0 1
+      				pitch = 1.0 1
+      				loop = true
+      			}
+
+        }
+    }
+}
+
+@PART[*]:HAS[@PLUME[BDB_Hypergolic_Lander],@EFFECTS:HAS[!engage]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        engage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = RealPlume/KW_Sounds/sound_liq6
+                volume = #$../../../PLUME[BDB_Hypergolic_Lander]/plumeScale$
+                pitch = 1.0
+                loop = false
+            }
+        }
+        disengage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_soft
+                volume = 1.0
+                pitch = 2.0
+                loop = false
+            }
+        }
+        flameout
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_explosion_low
+                volume = 1.0
+                pitch = 2.0
+                loop = false
+            }
+        }
+    }
+}

--- a/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Prefabs/BDB_Plume_Keys.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RealPlumes/BDB_Prefabs/BDB_Plume_Keys.cfg
@@ -26,6 +26,18 @@ BDBPlume
     //   density = #$@BDBPlume/atmosphereKeys/key4$ 0.5
     //   density = #$@BDBPlume/atmosphereKeys/key5$ 0
     // }
+
+    ///////Additional keys for special effects
+
+    //Shock cone keys, use a set of these to fade out shock cones before plume expansion begins
+
+
+    //Vacuum fade in, place after key3 to fade in a dedicated vacuum effect
+    key35 = 0.065
+
+    //Emission cut off. If alphaMult has been used to fade out an effect by key5 use key6 to kill emission of invisible particles afterwards.
+    key6 = 0.0
+
   }
 
   //Predefined power (throttle) keys mostly for better readability in the configs as well as consistency


### PR DESCRIPTION
New prefab for LMAE, LMDE and Gemini lander engines. Derived from Hypergolic upper white but smaller, more transparent, some effects removed.

Block III and Block V Apollo SPS engines also configured to match LMAE and LMDE