### PR TITLE
Engine Ignitor Compatibility

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/EngineIgnitor/Engine Ignitor Config Rules.txt
+++ b/Gamedata/Bluedog_DB/Compatibility/EngineIgnitor/Engine Ignitor Config Rules.txt
@@ -1,0 +1,7 @@
+Booster engines get 1 ignition
+
+AJ10 derivatives get 50 ignitions usually, check the RO wiki otherwise
+
+Have ullage enabled for all engines unless otherwise specified
+
+All engines get a 0.2 chance to ignite when unstable

--- a/Gamedata/Bluedog_DB/Compatibility/EngineIgnitor/EngineIgnitorBluedog.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/EngineIgnitor/EngineIgnitorBluedog.cfg
@@ -1,0 +1,795 @@
+//Configs redone for packaging with BDB by Rock3tman_
+
+
+//===AGENA SECTION==================================
+//Agena A - Belle-A-25 "Hadar"
+@PART[bluedog_AgenaA]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 2
+		AutoIgnitionTemperature = 500
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Agena D - Belle-D-35 "Mafuni"
+@PART[bluedog_AgenaD]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 8
+		AutoIgnitionTemperature = 500
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Agena secondary engine - Belle-D-4 "Nafuni"
+@PART[bluedog_agenaSecondaryEngine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 15
+		AutoIgnitionTemperature = 500
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//===END OF AGENA SECTION===
+
+//===APOLLO SECTION=================================
+//LMDE 
+@PART[bluedog_LEM_Descent_Engine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 380
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LMAE
+@PART[bluedog_LEM_Ascent_Engine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 10
+		AutoIgnitionTemperature = 450
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Apollo Block V LMDE - Kane-11-SE35
+@PART[bluedog_Apollo_Block5_ServiceEngine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 50
+		AutoIgnitionTemperature = 380
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Apollo Block III LMAE - Kane-11-SE12
+@PART[bluedog_Apollo_Block3_ServiceEngine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 50
+		AutoIgnitionTemperature = 450
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Apollo SPS AJ10 - Kane-11-SE60
+@PART[bluedog_Apollo_Block2_ServiceEngine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 50
+		AutoIgnitionTemperature = 330
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF APOLLO SECTION===
+
+//===ATLAS SECTION=============================
+//LR-101 - Bossart-IE-101I "Finch"
+@PART[bluedog_Atlas_LR101_Inline]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 32
+		AutoIgnitionTemperature = 430
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR-101 - Bossart-1E-101 - "Crow"
+@PART[bluedog_Atlas_LR101_Radial]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 430
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR89 - Bossart-1E-89 - Buzzard 
+@PART[bluedog_Atlas_LR89]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR105 - Bossart-1E-105 - Vulture
+@PART[bluedog_Atlas_LR105]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//RD-180 - Muo-V-DR180 "Czar"
+@PART[bluedog_AtlasV_RD180]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//===END OF ATLAS SECTION===
+
+//===CENTAUR SECTION============================
+//RL10 - Inon-R-10A "Isor"
+@PART[bluedog_Centaur_RL10]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 10
+		AutoIgnitionTemperature = 800
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//RL10A41 - Inon-R-10A41 "Sorau"
+@PART[bluedog_Centaur_RL10A41]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 15
+		AutoIgnitionTemperature = 800
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//RL10B2 - Inon-R-10B2 "Eisorau"
+@PART[bluedog_Centaur_RL10B2]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 15
+		AutoIgnitionTemperature = 800
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF CENTAUR SECTION===
+
+//===DELTA SECTION=======================================
+//Delta K AJ10 - Daleth-K-5-75 "Bahdal"
+@PART[bluedog_DeltaK_AJ10]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 50
+		AutoIgnitionTemperature = 800
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Delta II RS27 - Daleth-SSR-27a "Darkah"
+@PART[bluedog_Delta2_RS27]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 500
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF DELTA SECTION===
+
+//===EARLY ROCKETS SECTION=============================
+//Able - Viklun-12 "Alpha"
+@PART[bluedog_ableEngine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 500
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Ablestar - Fenris-18 "Alphastar"
+@PART[bluedog_ablestarEngine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 50
+		AutoIgnitionTemperature = 550
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Navaho - Viklun-405-000 "Dine"
+@PART[bluedog_navahoEngine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 550
+		 0
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Redstone - Etoh-140 "Sandstone"
+@PART[bluedog_redstone]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 550
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Thor Delta - Fenris-215 "Odin"
+@PART[bluedog_thorEngine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 550
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Vanguard - Viklun-50 "Viking"
+@PART[bluedog_vanguardEngine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 550
+		 = I-7
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF EARLY ROCKETS SECTION===
+
+//===ENGINE(FOLDER) SECTION=============================
+//E-1 - Prometheus RB-1E471 "Cordele" 
+@PART[bluedog_E1]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 550
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF ENGINE(FOLDER) SECTION===
+
+//===JUNO SECTION==============================
+//Juno 6K - Chryslus-6K "Seeker"
+@PART[bluedog_Juno_Engine6K]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Juno 45K - Chryslus-45K "Hunter"
+@PART[bluedog_Juno_Engine45K]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//S-3(D) - Chryslus-3DS "Polaris"
+@PART[bluedog_Juno_EngineS3D]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//bluedog junoVernier - Chryslus-EE5 "Rhesus"
+@PART[bluedog_Juno_EngineVernier]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF JUNO SECTION===
+
+//===SATURN SECTION=============================
+//F-1 - Sarnus-LE1F-2214 "Regor"
+@PART[bluedog_Saturn_Engine_F1]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 0
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//H-1C - Sarnus-HC1-280 "Grivan"
+@PART[bluedog_Saturn_Engine_H1C]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//H-1D - Sarnus-HD1-270 "Navi"
+@PART[bluedog_Saturn_Engine_H1D]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//J-2 - Sarnus-HE2J-550 "Dnoces"
+@PART[bluedog_Saturn_Engine_J2]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//J-2S - Sarnus-HE2J-570-S "Dnoces S"
+@PART[bluedog_Saturn_Engine_J2S]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//J-2SL - Sarnus-HESL2J-475 "Dnoces Sea Level"
+@PART[bluedog_Saturn_Engine_J2SL]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//J-2T - Sarnus-HE2JT-200K "Tohces"
+@PART[bluedog_Saturn_Engine_J2T]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//J-2X - Sarnus-HE2JX-447 "Dnoces"
+@PART[bluedog_Saturn_Engine_J2X]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//===END OF SATURN SECTION===
+
+//===TITAN SECTION===========================
+
+//LR87-3 - Prometheus LR8703-367 "Perses"
+@PART[bluedog_LR87_3]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR87-5 - Prometheus-II-675 "Pallas"
+@PART[bluedog_LR87_5]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR87-11 - Prometheus-IV-700 "Astreous"
+@PART[bluedog_LR87_11]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR87 Single Chamber - Prometheus LR8711-303 "Astoria"
+@PART[bluedog_LR87_11_Single]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR87 Single Chamber Vac - Prometheus LR8711V-303 "Astoria"
+@PART[bluedog_LR87_11_Vac]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 2
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR87 LH2 Sea Level - Prometheus LE87H2-SL "Perseus"
+@PART[bluedog_LR87_LH2_SL]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 2
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR87 LH2 Vac - Prometheus LE87H2-V "Perseus" Cryogenic Engine
+@PART[bluedog_LR87_LH2_V]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 2
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR91-3 - Prometheus LR9103-133 "Leto"
+@PART[bluedog_LR91_3]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR91-5 - Prometheus LR9107-167 "Lelantos"
+@PART[bluedog_LR91_5]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 650
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//LR91-11 - Prometheus LR9111-177 "Asteria"
+@PART[bluedog_LR91_11]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 400
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Transtage - Prometheus-III-S3 "Metis" Upper Stage
+@PART[bluedog_Titan_Transtage]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 50
+		AutoIgnitionTemperature = 600
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF TITAN SECTION===
+
+//===VEGA SECTION===========================
+//Vega - Vejur-E78 "Decker"
+@PART[bluedog_Vega_Engine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 2
+		AutoIgnitionTemperature = 600
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF VEGA SECTION===
+
+//===GEMINI SECTION===========================
+//Gemini Lander - Dona-LDAE8
+@PART[bluedog_Gemini_Lander_Engine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 20
+		AutoIgnitionTemperature = 600
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//Gemini Lander - Dona-LDAE8
+@PART[bluedog_Gemini_Lander_Engine]:NEEDS[EngineIgnitor]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 20
+		AutoIgnitionTemperature = 600
+		 
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF GEMINI SECTION===


### PR DESCRIPTION
Added compatibility patch for Engine Ignitor to reflect realistic numbers of relights for most BDB engines. Ullage requirements are disabled as the functionality currently seems to be broken in the latest version of Engine Ignitor.