### PR TITLE
Optional upper stage thrust nerf

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/UpperStageThrustNerf/BDBUpperStageThrustNerf.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/UpperStageThrustNerf/BDBUpperStageThrustNerf.cfg
@@ -1,0 +1,143 @@
+@PART[bluedog_AgenaA|bluedog_AgenaD|bluedog_Centaur_RL10|bluedog_Centaur_RL10A41|bluedog_Centaur_RL10B2|bluedog_DeltaK_AJ10|bluedog_ablestarEngine|bluedog_ableEngine|bluedog_Juno_Engine6K|bluedog_Juno_Engine45K|bluedog_Vega_Engine|bluedog_Gemini_Lander_Engine]:FOR[zBDBUpperStageThrustNerf]
+{
+    @mass *= 0.5
+    @cost *= 0.5
+
+    @MODULE[ModuleEngines*]
+    {
+        @maxThrust *= 0.5
+        @minThrust *= 0.5
+
+        @UPGRADES
+        {
+            @UPGRADE,*
+            {
+                @maxThrust *= 0.5
+                @minThrust *= 0.5
+            }
+        }
+    }
+
+    @MODULE[PartStatsUpgradeModule]
+    {
+        @UPGRADES
+        {
+            @UPGRADE,*
+            {
+                @PartStats
+                {
+                    @mass *= 0.5
+                    @cost *= 0.5
+                }
+            }
+        }
+    }
+
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+    {
+        @SUBTYPE,*
+        {
+            @addedMass *= 0.5
+            @addedCost *= 0.5
+
+            @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+            {
+                @DATA
+                {
+                    @maxThrust *= 0.5
+                    @minThrust *= 0.5
+                }
+            }
+        }
+    }
+}
+
+@PART[bluedog_Apollo_Block2_ServiceEngine]:FOR[zBDBUpperStageThrustNerf]
+{
+    @mass *= 0.37
+    @cost *= 0.37
+
+    @MODULE[ModuleEngines*]
+    {
+        @maxThrust *= 0.37
+        @minThrust *= 0.37
+    }
+}
+
+@PART[bluedog_Apollo_Block3_ServiceEngine|bluedog_LEM_Ascent_Engine]:FOR[zBDBUpperStageThrustNerf]
+{
+    @mass *= 0.32
+    @cost *= 0.32
+
+    @MODULE[ModuleEngines*]
+    {
+        @maxThrust *= 0.32
+        @minThrust *= 0.32
+    }
+}
+
+@PART[bluedog_Apollo_Block5_ServiceEngine|bluedog_LEM_Descent_Engine]:FOR[zBDBUpperStageThrustNerf]
+{
+    @mass *= 0.33
+    @cost *= 0.33
+
+    @MODULE[ModuleEngines*]
+    {
+        @maxThrust *= 0.33
+        @minThrust *= 0.33
+    }
+}
+
+@PART[bluedog_Saturn_Engine_J2|bluedog_Saturn_Engine_J2S|bluedog_Saturn_Engine_J2SL|bluedog_Saturn_Engine_J2T|bluedog_Saturn_Engine_J2X|bluedog_LR87_LH2_SL|bluedog_LR87_LH2_V|bluedog_LR91_3|bluedog_LR91_5|bluedog_LR91_11]:FOR[zBDBUpperStageThrustNerf]
+{
+    @mass /= 1.5
+    @cost /= 1.5
+
+    @MODULE[ModuleEngines*],*
+    {
+        @maxThrust /= 1.5
+        @minThrust /= 1.5
+
+        @UPGRADES
+        {
+            @UPGRADE,*
+            {
+                @maxThrust /= 1.5
+                @minThrust /= 1.5
+            }
+        }
+    }
+
+    @MODULE[PartStatsUpgradeModule]
+    {
+        @UPGRADES
+        {
+            @UPGRADE,*
+            {
+                @PartStats
+                {
+                    @mass /= 1.5
+                    @cost /= 1.5
+                }
+            }
+        }
+    }
+
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+    {
+        @SUBTYPE,*
+        {
+            @addedMass /= 1.5
+            @addedCost /= 1.5
+
+            @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+            {
+                @DATA
+                {
+                    @maxThrust /= 1.5
+                    @minThrust /= 1.5
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sets all engines to 25% real thrust (mainly uppers) for those who are okay with looong burn times.  Reduce mass and cost to compensate.