### PR TITLE
Update bluedog_Skylab_ATM.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Skylab/bluedog_Skylab_ATM.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Skylab/bluedog_Skylab_ATM.cfg
@@ -111,7 +111,7 @@ PART
 		packetCeiling = 5
 	}
 
-	MODULE:NEEDS[AsteroidDay]
+	MODULE
 	{
 		name = ModuleScienceExperiment
 		experimentID = infraredTelescope
@@ -129,7 +129,7 @@ PART
 		usageReqMaskExternal = 8
 	}
 
-	MODULE:NEEDS[AsteroidDay]
+	MODULE
 	{
 		name = SentinelModule
 	}


### PR DESCRIPTION
Remove NEEDS:AsteroidDay, since the former mod (with its science experiment and asteroid module) is now included in the stock game.