### PR TITLE
Tianjia panel and CELV booster skirt realnames fix

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Gemini/Solar/bluedog_Tianja_LargeFixedSolar.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/Solar/bluedog_Tianja_LargeFixedSolar.cfg
@@ -17,9 +17,9 @@ MODEL
 	title = MOS-DOTD-F2 Fixed Solar Array
 	manufacturer = Bluedog Design Bureau
 	description = Large, heavy solar panels imported from the far East. Primitive, but capable of generating more power than anything else with our current technology. Hopefully we'll come up with something better soon. //'
-	real_title = Tianja Large Fixed Solar Array
+	real_title = Tianjia Large Fixed Solar Array
 	real_manufacturer = China Aerospace Science and Technology Corporation
-	real_description = Solar panels as used on the Tianja Space Station in Dawn of the Dragon.
+	real_description = Solar panels as used on the Tianjia Space Station in Dawn of the Dragon.
 	attachRules = 0,1,0,0,1
 	mass = 0.210
 	dragModelType = default

--- a/Gamedata/Bluedog_DB/Parts/Gemini/Solar/bluedog_Tianja_LargeRotatingSolar.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/Solar/bluedog_Tianja_LargeRotatingSolar.cfg
@@ -17,9 +17,9 @@ MODEL
 	title = MOS-DOTD-R2 Tracking Solar Array
 	manufacturer = Bluedog Design Bureau
 	description = Large, heavy solar panels imported from the far East. Primitive, but capable of generating more power than anything else with our current technology. Hopefully we'll come up with something better soon. //'
-	real_title = Tianja Large Tracking Solar Array
+	real_title = Tianjia Large Tracking Solar Array
 	real_manufacturer = China Aerospace Science and Technology Corporation
-	real_description = Solar panels as used on the Tianja Space Station in Dawn of the Dragon.
+	real_description = Solar panels as used on the Tianjia Space Station in Dawn of the Dragon.
 	attachRules = 0,1,0,0,1
 	mass = 0.31
 	dragModelType = default

--- a/Gamedata/Bluedog_DB/Parts/Gemini/Solar/bluedog_Tianja_SmallFixedSolar.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/Solar/bluedog_Tianja_SmallFixedSolar.cfg
@@ -17,9 +17,9 @@ MODEL
 	title = MOS-DOTD-F1 Fixed Solar Array
 	manufacturer = Bluedog Design Bureau
 	description = Large, heavy solar panels imported from the far East. Primitive, but capable of generating more power than anything else with our current technology. Hopefully we'll come up with something better soon. //'
-	real_title = Tianja Small Fixed Solar Array
+	real_title = Tianjia Small Fixed Solar Array
 	real_manufacturer = China Aerospace Science and Technology Corporation
-	real_description = Solar panels as used on the Tianja Space Station in Dawn of the Dragon.
+	real_description = Solar panels as used on the Tianjia Space Station in Dawn of the Dragon.
 	attachRules = 0,1,0,0,1
 	mass = 0.105
 	dragModelType = default

--- a/Gamedata/Bluedog_DB/Parts/Gemini/Solar/bluedog_Tianja_SmallRotatingSolar.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/Solar/bluedog_Tianja_SmallRotatingSolar.cfg
@@ -17,9 +17,9 @@ MODEL
 	title = MOS-DOTD-R1 Tracking Solar Array
 	manufacturer = Bluedog Design Bureau
 	description = Large, heavy solar panels important from the far East. Primitive, but capable of generating more power than anything else with our current technology. Hopefully we'll come up with something better soon. //'
-	real_title = Tianja Small Tracking Solar Array
+	real_title = Tianjia Small Tracking Solar Array
 	real_manufacturer = China Aerospace Science and Technology Corporation
-	real_description = Solar panels as used on the Tianja Space Station in Dawn of the Dragon.
+	real_description = Solar panels as used on the Tianjia Space Station in Dawn of the Dragon.
 	attachRules = 0,1,0,0,1
 	mass = 0.155
 	dragModelType = default

--- a/Gamedata/Bluedog_DB/Parts/LDC/bluedog_CELV_BoosterSkirt.cfg
+++ b/Gamedata/Bluedog_DB/Parts/LDC/bluedog_CELV_BoosterSkirt.cfg
@@ -55,7 +55,7 @@ MODEL
 	title = Bossart-ADLV-DES Booster Skirt
 	manufacturer = Bluedog Design Bureau
 	description = Fairing for covering the booster engines on Bossart ADLV rockets. Attach the booster engines to the four outer nodes, and stage them away once you no longer need the thrust.
-	real_title = Atlas Booster Skirt
+	real_title = Atlas CELV Booster Skirt
 	real_manufacturer = Convair
 	real_description = Fairing for covering the booster engines on Atlas CELV rockets. Attach the booster engines to the four outer nodes, and stage them away once you no longer need the thrust.
 	attachRules = 1,0,1,1,0


### PR DESCRIPTION
Found out that e of pi named the Chinese stations in DOTD Tianjia (天家), not Tianja.