### PR TITLE
Fix for -RealNames blocking load

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/Saturn INT series Parts/Saturn_S1_INT11_Tank.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/Saturn INT series Parts/Saturn_S1_INT11_Tank.cfg
@@ -3,30 +3,27 @@
 	@name = bluedog_Saturn_S1_11_Tankage_x
 	@MODEL
 	{
-		%scale = 1, 1.25, 1
+		%scale = 1, 1.24, 1
 	}
-	@node_stack_top[1,,] *= 1.25
-	@node_stack_bottom[1,,] *= 1.25
+	@node_stack_top[1,,] *= 1.24
+	@node_stack_bottom[1,,] *= 1.24
 	@cost *= 1.33
 	@mass *= 1.07
 	@title = Sarnus-SI-11-13900 Liquid Fuel Tank
-	manufacturer = Pafftek_Enterprises in conjunction with Bluedog Design Bureau
-	description = LFO tank for the Sarnus-S1-11 stretched first stage, made up of eight modified Etoh fuel tanks wrapped around a modified Chryslus fuel tank. This version is to be used in conjunction with 2 Prometheus-III-7 "Helios" Solid Rocket Booster at launch
+	%manufacturer = Pafftek_Enterprises in conjunction with Bluedog Design Bureau
+	%description = LFO tank for the Sarnus-S1-11 stretched first stage, made up of eight modified Etoh fuel tanks wrapped around a modified Chryslus fuel tank. This version is to be used in conjunction with 2 Prometheus-III-7 "Helios" Solid Rocket Booster at launch
+	%real_title = Saturn I-INT11 tankage
+	%real_description = Post Apollo program stretched Saturn tankage.  Has about a 25% increase in fuel capacity  For launching inter-planetary probes and station components.
+	%real_manufacturer = Chrysler (Redstone Arsenal) 
+	@tags = saturn 3.75m sarnus ?s1 ?si first stage fuel tank large big INT	
 	@RESOURCE[LiquidFuel]
 	{
-		@amount *= 1.18
-		@maxAmount *= 1.18
+		@amount *= 1.164
+		@maxAmount *= 1.164
 	}
 	@RESOURCE[Oxidizer]
 	{
-		@amount *= 1.18
-		@maxAmount *= 1.18
+		@amount *= 1.164
+		@maxAmount *= 1.164
 	}
 }	
-
-@PART[bluedog_Saturn_S1_11_Tankage_x]:NEEDS[Bluedog_Realnames]
-{
-	@title = Saturn INT-11/-13/-14/-15 tank
-	@description = Tall Cluster.  A 20 foot stretched Cluster tank segment.  Still not efficient but it was proposed and built.  Needs E-1 engines or SRMs for best performance.
-	
-}

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/Saturn MLV Series parts/SaturnV_MLV_Tanks.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/Saturn MLV Series parts/SaturnV_MLV_Tanks.cfg
@@ -14,10 +14,13 @@
 	@title = Sarnus-MS1C-25 Liquid Fuel Tank
 	@description = Extended tankage for the Massive MS-IC stage of Sarnus.
 	@mass = 51.57
-	@tags = saturn 5.625m sarnus ?s1e ?sie first stage fuel tank large big multibody SCC ets
-	%real_title = Saturn MS-IC tankage
-	%real_description = Post Apollo program stretched Saturn tankage.  Has about a 25% increase in fuel capacity  For launching inter-planetary probes and station components.
+	@tags = saturn 5.625m sarnus first stage fuel tank large big MLV MS1C
+	%real_title = Saturn MS-IC-25 tankage
+	%real_description = Post Apollo program stretched Saturn tankage.  Has about a 25% increase in fuel capacity and a length increased 12.64 meters  For launching inter-planetary probes and station components.  The longest lenght S-IC stretch proposed for MLV and quickly discarded as un-usable.
 	%real_manufacturer = Boeing (Michoud Government owned factory)
+	@crashTolerance = 18
+	@breakingForce = 1000
+	@breakingTorque = 1000			
 		
 	
 	@RESOURCE[LiquidFuel]
@@ -42,14 +45,15 @@
 	@node_stack_top[1,,] *= 1.3
 	@node_stack_bottom[1,,] *= 1.3
 	@entryCost *= 1.45
-	@cost *= 1.53
+	@cost *= 3.5
 	@title = Sarnus-MS1C-25 Liquid Fuel Tank
 	@description = Extended tankage for the Massive MS-IC stage of Sarnus with a flat Bulkhead.
-	@mass = 50.22
+	@mass = 53.5
 	@tags = saturn 5.625m sarnus ?s1e ?sie first stage fuel tank large big multibody SCC ets
-	%real_title = Saturn MS-1C Flat Bulkhead (FB) tankage
-	%real_description = Post Apollo program Saturn tankage.  As designed the S-IC tank was built with large void areas to save years of engineering.  This Flat Bulkhead tankage is in the Stretched MS-1C height further increasing fuel capacity over any other S-IC stage tankage.
-	%real_manufacturer = Boeing (Michoud Government owned factory)	
+	%real_title = Saturn MS-1C-25FB Common Bulkhead stretched tankage
+	%real_description = Post Apollo program Saturn tankage.  As designed the S-IC tank was built with large void areas to save years of engineering.  This Flat Bulkhead tankage is in the Stretched MS-1C height further increasing fuel capacity over any other S-IC stage tankage.  Never proposed and completely hypothetical conclusion of Common bulkhead and tank stretch.
+	%real_manufacturer = Boeing (Michoud Government owned factory)
+		
 	
 	@RESOURCE[LiquidFuel]
 	{
@@ -68,18 +72,115 @@
 	@author = CobaltWolf Feat. Pappystein
 	@MODEL
 	{
-		%scale = 1, 0.81, 1
+		%scale = 1, 0.86, 1
 	}
-	@node_stack_top[1,,] *= 0.81
-	@node_stack_bottom[1,,] *= 0.81
-	@mass *= 0.98
-	@cost *= 1.25
-	@title = Sarnus-S-1C Flat Bulkhead
+	@node_stack_top[1,,] *= 0.86
+	@node_stack_bottom[1,,] *= 0.86
+	@mass *= 0.94
+	@cost *= 1.2
+	@title = Sarnus-S-1C Forshortened Common Bulkhead
 	@description = a Standard Sarnus-S-1C tank has large void spaces.  This tank, whiles only saving a little weight saves a lot of height.
 	@tags = saturn 5.625m sarnus ?s1e ?sie first stage fuel tank large big multibody SCC ets
 	%real_title = Saturn S-IC-FB Flat Bulkhead (FB) tankage
 	%real_description = Post Apollo program Saturn tankage.  As designed the S-IC tank was built with large void areas to save years of engineering.  This tank, whiles only saving a little weight saves a lot of height.  Stock S-1C fuel capacity.
-	%real_manufacturer = Boeing (Michoud Government owned factory)	
+	%real_manufacturer = Boeing (Michoud Government owned factory)
+	@crashTolerance = 18
+	@breakingForce = 1000
+	@breakingTorque = 1000			
+}
++PART[bluedog_Saturn_S1C_Tankage]
+{
+	@name = bluedog_Saturn_MS1C_FB_tankage_x
+	@author = CobaltWolf Feat. Pappystein
+	@mass *= 0.94
+	@cost *= 1.2
+	@title = Sarnus-S-1C Flat Bulkhead
+	@description = a Standard Sarnus-S-1C tank has large void spaces.  This tank, while the same height as the S-IC adds much more fuel.
+	@tags = saturn 5.625m sarnus ?s1e ?sie first stage fuel tank large big multibody SCC ets
+	%real_title = Saturn MS-IC-FB Flat Bulkhead (FB) tankage
+	%real_description = Post Apollo program Saturn tankage.  As designed the S-IC tank was built with large void areas to save years of engineering.  By utilizing the Flat or Common Bulkhead in a Standard S-IC tankage, the MS-1CFB can carry 12% more fuel within the same height.
+	%real_manufacturer = Boeing (Michoud Government owned factory)
+	@crashTolerance = 18
+	@breakingForce = 1000
+	@breakingTorque = 1000	
+	@RESOURCE[LiquidFuel]
+	{
+		@amount *= 1.12
+		@maxAmount *= 1.12
+	}
+	@RESOURCE[Oxidizer]
+	{
+		@amount *= 1.12
+		@maxAmount *= 1.12
+	}	
+}
++PART[bluedog_Saturn_S1C_Tankage]
+{
+	@name = bluedog_Saturn_MS1C3B_Tankage_X
+	@author = CobaltWolf Feat. Pappystein
+	@MODEL
+	{
+		%scale = 1, 1.14, 1
+	}
+	@node_stack_top[1,,] *= 1.14
+	@node_stack_bottom[1,,] *= 1.14
+	@entryCost *= 1.2
+	@cost *= 1.2
+	@title = Sarnus-MS1C-3B Liquid Fuel Tank
+	@description = Extended tankage for the Massive MS-IC stage of Sarnus.
+	@mass *= 1.16
+	@tags = saturn 5.625m sarnus first stage fuel tank large big MLV MS1C
+	%real_title = Saturn MS-IC-3B tankage
+	%real_description = Post Apollo program stretched Saturn tankage.  20ft / 240inch stretch of standard S-IC tankage with slight structural improvement. Longest "ideal" tank stretch due to VAB height.
+	%real_manufacturer = Boeing (Michoud Government owned factory)
+	@crashTolerance = 18
+	@breakingForce = 1000
+	@breakingTorque = 1000		
+	
+	@RESOURCE[LiquidFuel]
+	{
+		@amount *= 1.18
+		@maxAmount *= 1.18
+	}
+	@RESOURCE[Oxidizer]
+	{
+		@amount *= 1.18
+		@maxAmount *= 1.18
+	}
+}
++PART[bluedog_Saturn_S1C_Tankage]
+{
+	@name = bluedog_Saturn_MS1C4SB_Tankage_X
+	@author = CobaltWolf Feat. Pappystein
+	@MODEL
+	{
+		%scale = 1, 1.2, 1
+	}
+	@node_stack_top[1,,] *= 1.2
+	@node_stack_bottom[1,,] *= 1.2
+	@entryCost *= 1.3
+	@cost *= 1.3
+	@title = Sarnus-MS1C-3B Liquid Fuel Tank
+	@description = Extended tankage for the Massive MS-IC stage of Sarnus.
+	@mass *= 1.18
+	@tags = saturn 5.625m sarnus first stage fuel tank large big MLV MS1C
+	%real_title = Saturn MS-IC-4(S)B tankage
+	%real_description = Post Apollo program stretched Saturn tankage.  28ft / 336 inch stretch of standard S-IC tankage with slight structural improvement. Actually too long to use for most Saturn Proposals due to VAB roof height.
+	%real_manufacturer = Boeing (Michoud Government owned factory)
+	@crashTolerance = 18
+	@breakingForce = 1000
+	@breakingTorque = 1000		
+	
+	@RESOURCE[LiquidFuel]
+	{
+		@amount *= 1.2
+		@maxAmount *= 1.2
+	}
+	@RESOURCE[Oxidizer]
+	{
+		@amount *= 1.2
+		@maxAmount *= 1.2
+	}
 }
 +PART[bluedog_Saturn_S2_Tankage]
 {
@@ -95,13 +196,13 @@
 	@cost *= 1.28
 	@title = Sarnus-MSIIA Liquid Fuel Tank
 	@description = Extended tankage for the massive MS-IIA stage of Sarnus.
-	@mass = 18.16
-	@tags = saturn 5.625m sarnus ?s1e ?sie first stage fuel tank large big multibody SCC ets
-	%real_title = Saturn MS-IIA tankage
-	%real_description = Post Apollo program stretched Saturn tankage.  A stretched Saturn V S-II stage for launching inter-planetary probes and station components.  About a 20% increase in fuel capacity.
+	@mass *= 1.064
+	@tags = saturn 5.625m sarnus MSIIA MLV 
+	%real_title = Saturn MS-II-1 tankage
+	%real_description = Post Apollo program stretched Saturn tankage.  A 41 inch stretch to the Saturn V S-II stage for launching inter-planetary probes and station components.  About a 20% increase in fuel capacity.  41 Inch Stretch
 	%real_manufacturer = North American Aviation (NAA)		
 	
-	@RESOURCE[LiquidFuel]
+	@RESOURCE[LqdHydrogen]
 	{
 		@amount *= 1.19
 		@maxAmount *= 1.19
@@ -110,5 +211,36 @@
 	{
 		@amount *= 1.19
 		@maxAmount *= 1.19
+	}
+}
++PART[bluedog_Saturn_S2_Tankage]
+{
+	@name = bluedog_Saturn_MSIIB_Tankage_X
+	@author = CobaltWolf Feat. Pappystein
+	@MODEL
+	{
+		%scale = 1, 1.2, 1
+	}
+	@node_stack_top[1,,] *= 1.2
+	@node_stack_bottom[1,,] *= 1.2
+	@entryCost *= 1.68
+	@cost *= 1.628
+	@title = Sarnus-MSIIB Liquid Fuel Tank
+	@description = Extended tankage for the massive MS-IIB stage of Sarnus.
+	@mass *= 1.177
+	@tags = saturn 5.625m sarnus MSIIB MLV 
+	%real_title = Saturn MS-II-2 tankage
+	%real_description = Post Apollo program stretched Saturn tankage.  A 187 inch stretch of the Saturn V S-II stage for launching inter-planetary probes and station components.  About a 30% increase in fuel capacity.  187 Inch Stretch
+	%real_manufacturer = North American Aviation (NAA)		
+	
+	@RESOURCE[LqdHydrogen]
+	{
+		@amount *= 1.3
+		@maxAmount *= 1.3
+	}
+	@RESOURCE[Oxidizer]
+	{
+		@amount *= 1.3
+		@maxAmount *= 1.3
 	}
 }


### PR DESCRIPTION
Due to RealNames being moved just prior to Release... Other Extras Folder Items were No longer loading.

This solves the issue and also fixes the MS-IC variants to clearly delineate Hypothetical (1 never proposed) and all the variant tanks (5?)   