### PR TITLE
CTT -> UnKerballedStart etc.

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/CommunityTechTree/CTT.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/CommunityTechTree/CTT.cfg
@@ -1,52 +1,52 @@
-@PART[bluedog_Apollo_Block3_Capsule]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Apollo_Block3_Capsule]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = heavyCommandModules
 }
-@PART[bluedog_Apollo_Block3_HGA]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Apollo_Block3_HGA]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = heavyCommandModules
 }
-@PART[bluedog_Apollo_Block3_Capsule]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Apollo_Block3_Capsule]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = heavyCommandModules
 }
-@PART[bluedog_Gemini_RCS_B]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Gemini_RCS_B]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = advFlightControl
 }
-@PART[bluedog_Gemini_Crew_B]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Gemini_Crew_B]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = simpleCommandModules
 }
-@PART[bluedog_Gemini_Heatshield_B]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Gemini_Heatshield_B]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = simpleCommandModules
 }
-@PART[bluedog_Gemini_MalhenaSM]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Gemini_MalhenaSM]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = enhancedSurvivability
 }
-@PART[bluedog_malhenaSolar]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_malhenaSolar]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = enhancedSurvivability
 }
-@PART[bluedog_Apollo_AARDV*]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Apollo_AARDV*]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = logistics
 }
-@PART[bluedog_Gemini_Resupply_Capsule]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Gemini_Resupply_Capsule]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = advFlightControl
 }
-@PART[bluedog_MOL_KISmodule]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_MOL_KISmodule]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = storageTech
 }
-@PART[bluedog_Agena_ResupplyContainer]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_Agena_ResupplyContainer]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = basicScience
 }
-@PART[bluedog_MOL_Lab]:NEEDS[CommunityTechTree]:FINAL
+@PART[bluedog_MOL_Lab]:NEEDS[CommunityTechTree]:FOR[Bluedog_DB]
 {
 	@TechRequired = spaceExploration
 }


### PR DESCRIPTION
I just recognized that the GameData\Bluedog_DB\Compatibility\CommunityTechTree\CTT.cfg overwrites some of those UnKerballedStart patches, because it's :FINAL

I suggest :FOR[Bluedog_DB]

This way it would be compatible to UnKerballedStart and ProbesBeforeCrew and what not.