### PR TITLE
bluedog_telstar gets node_stack_top back

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Antennas/bluedog_telstarAntenna.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Antennas/bluedog_telstarAntenna.cfg
@@ -11,6 +11,7 @@ MODEL
 }
 	scale = 1
 	rescaleFactor = 1.0
+	node_stack_top = 0.0, 0.15, 0.0, 0.0, 1.0, 0.0, 0
 	node_stack_bottom = 0.0, -0.0134, 0.0, 0.0, -1.0, 0.0, 0
 	node_attach = 0.0, -0.0134, 0.0, 0.0, -1.0, 0.0, 0
 	TechRequired = survivability
@@ -23,7 +24,7 @@ MODEL
 	description  = This lightweight communications antenna is stack mountable, and provides omnidirectional coverage for sending and receiving commands.
 	real_title = Telstar Helical Antenna
 	real_manufacturer = AT&T, Bell Laboratories
-	attachRules = 1,1,0,0,1
+	attachRules = 1,1,1,0,1
 	mass = 0.02
 	dragModelType = default
 	maximum_drag = 0.20


### PR DESCRIPTION
to fix
https://github.com/CobaltWolf/Bluedog-Design-Bureau/issues/741

Part's description says
> This lightweight communications antenna is stack mountable, and provides omnidirectional coverage for sending and receiving commands.

This fix makes it true again.