### PR TITLE
Create SafeSolid shutdown with AG Brakes.cfg

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
@@ -1,5 +1,11 @@
 // Adds the action group "Brakes" to all solid fuel engines with the SafeSolid™ system, allows it to shutdown the engine quickly by pressing "B" (default keybinding for "Brakes")
 
+// If it's a SolidFuel engine which can be shut down, but got the SafeSolid™ not mentioned in the description yet, change this and mention it
+@PART[bluedog*,Bluedog*]:HAS[~description[*SafeSolid*],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+{
+	@description = #$description$ It features BDB's SafeSolid™ system, allowing the engine to be shut down in flight, allowing for more accurate orbital insertions and manuevers.
+}
+
 // already existing with index 0, so add another ModuleBdbDefAGHelper with index 1
 // ModuleEngines
 @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
@@ -1,0 +1,59 @@
+// Adds the action group "Brakes" to all solid fuel engines with the SafeSolid™ system, allows it to shutdown the engine quickly by pressing "B" (default keybinding for "Brakes")
+
+// already existing with index 0, so add another ModuleBdbDefAGHelper with index 1
+@PART]bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+{
+	// ModuleEngines
+	@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
+	{
+		MODULE
+		{
+			name = ModuleBdbDefAGHelper
+			actionModuleName = ModuleEngines
+			actionModuleIndex = 1
+			actionName = ShutdownEngine
+			actionDefaultActionGroup = Brakes
+		}
+	}
+	// ModuleEnginesFX
+	@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
+	{
+		MODULE
+		{
+			name = ModuleBdbDefAGHelper
+			actionModuleName = ModuleEnginesFX
+			actionModuleIndex = 1
+			actionName = ShutdownEngine
+			actionDefaultActionGroup = Brakes
+		}
+	}
+}
+
+// not existing yet, so add the ModuleBdbDefAGHelper with index 0
+@PART]bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+{
+	// ModuleEngines
+	@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
+	{
+		MODULE
+		{
+			name = ModuleBdbDefAGHelper
+			actionModuleName = ModuleEngines
+			actionModuleIndex = 0
+			actionName = ShutdownEngine
+			actionDefaultActionGroup = Brakes
+		}
+	}
+	// ModuleEnginesFX
+	@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
+	{
+		MODULE
+		{
+			name = ModuleBdbDefAGHelper
+			actionModuleName = ModuleEnginesFX
+			actionModuleIndex = 0
+			actionName = ShutdownEngine
+			actionDefaultActionGroup = Brakes
+		}
+	}
+}

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
@@ -2,7 +2,7 @@
 
 // already existing with index 0, so add another ModuleBdbDefAGHelper with index 1
 // ModuleEngines
-@PART]bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+@PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
 	MODULE
 	{
@@ -14,7 +14,7 @@
 	}
 }
 // ModuleEnginesFX
-@PART]bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+@PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
 	MODULE
 	{
@@ -28,7 +28,7 @@
 
 // not existing yet, so add the ModuleBdbDefAGHelper with index 0
 // ModuleEngines
-@PART]bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+@PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
 	MODULE
 	{
@@ -40,7 +40,7 @@
 	}
 }
 // ModuleEnginesFX
-@PART]bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+@PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
 	MODULE
 	{

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
@@ -15,7 +15,7 @@
 		name = ModuleBdbDefAGHelper
 		actionModuleName = ModuleEngines
 		actionModuleIndex = 1
-		actionName = ShutdownEngine
+		actionName = ShutdownAction
 		actionDefaultActionGroup = Brakes
 	}
 }
@@ -27,7 +27,7 @@
 		name = ModuleBdbDefAGHelper
 		actionModuleName = ModuleEnginesFX
 		actionModuleIndex = 1
-		actionName = ShutdownEngine
+		actionName = ShutdownAction
 		actionDefaultActionGroup = Brakes
 	}
 }
@@ -41,7 +41,7 @@
 		name = ModuleBdbDefAGHelper
 		actionModuleName = ModuleEngines
 		actionModuleIndex = 0
-		actionName = ShutdownEngine
+		actionName = ShutdownAction
 		actionDefaultActionGroup = Brakes
 	}
 }
@@ -53,7 +53,7 @@
 		name = ModuleBdbDefAGHelper
 		actionModuleName = ModuleEnginesFX
 		actionModuleIndex = 0
-		actionName = ShutdownEngine
+		actionName = ShutdownAction
 		actionDefaultActionGroup = Brakes
 	}
 }

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
@@ -8,6 +8,7 @@
 
 @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
+	@description = #$description$ Just press the "Brakes" button (default "B") to do so.
 	@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
 	{
 		%ACTIONS
@@ -19,6 +20,9 @@
 		}
 	}
 }
+
+// remark: could be generally patched into all parts, not just BDB parts
+
 
 // already existing with index 0, so add another ModuleBdbDefAGHelper with index 1
 // ModuleEngines

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
@@ -6,54 +6,68 @@
 	@description = #$description$ It features BDB's SafeSolid™ system, allowing the engine to be shut down in flight, allowing for more accurate orbital insertions and manuevers.
 }
 
-// already existing with index 0, so add another ModuleBdbDefAGHelper with index 1
-// ModuleEngines
-@PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+@PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
-	MODULE
+	@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
 	{
-		name = ModuleBdbDefAGHelper
-		actionModuleName = ModuleEngines
-		actionModuleIndex = 1
-		actionName = ShutdownAction
-		actionDefaultActionGroup = Brakes
-	}
-}
-// ModuleEnginesFX
-@PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
-{
-	MODULE
-	{
-		name = ModuleBdbDefAGHelper
-		actionModuleName = ModuleEnginesFX
-		actionModuleIndex = 1
-		actionName = ShutdownAction
-		actionDefaultActionGroup = Brakes
+		%ACTIONS
+		{
+			%ShutdownAction
+			{
+				%actionGroup = Brakes
+			}
+		}
 	}
 }
 
+// already existing with index 0, so add another ModuleBdbDefAGHelper with index 1
+// ModuleEngines
+// @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+// {
+	// MODULE
+	// {
+		// name = ModuleBdbDefAGHelper
+		// actionModuleName = ModuleEngines
+		// actionModuleIndex = 1
+		// actionName = ShutdownAction
+		// actionDefaultActionGroup = Brakes
+	// }
+// }
+// ModuleEnginesFX
+// @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+// {
+	// MODULE
+	// {
+		// name = ModuleBdbDefAGHelper
+		// actionModuleName = ModuleEnginesFX
+		// actionModuleIndex = 1
+		// actionName = ShutdownAction
+		// actionDefaultActionGroup = Brakes
+	// }
+// }
+
 // not existing yet, so add the ModuleBdbDefAGHelper with index 0
 // ModuleEngines
-@PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
-{
-	MODULE
-	{
-		name = ModuleBdbDefAGHelper
-		actionModuleName = ModuleEngines
-		actionModuleIndex = 0
-		actionName = ShutdownAction
-		actionDefaultActionGroup = Brakes
-	}
-}
+// @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+// {
+	// MODULE
+	// {
+		// name = ModuleBdbDefAGHelper
+		// actionModuleName = ModuleEngines
+		// actionModuleIndex = 0
+		// actionName = ShutdownAction
+		// actionDefaultActionGroup = Brakes
+	// }
+// }
 // ModuleEnginesFX
-@PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
-{
-	MODULE
-	{
-		name = ModuleBdbDefAGHelper
-		actionModuleName = ModuleEnginesFX
-		actionModuleIndex = 0
-		actionName = ShutdownAction
-		actionDefaultActionGroup = Brakes
-	}
-}
+// @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+// {
+	// MODULE
+	// {
+		// name = ModuleBdbDefAGHelper
+		// actionModuleName = ModuleEnginesFX
+		// actionModuleIndex = 0
+		// actionName = ShutdownAction
+		// actionDefaultActionGroup = Brakes
+	// }
+// }

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
@@ -6,6 +6,7 @@
 	@description = #$description$ It features BDB's SafeSolid™ system, allowing the engine to be shut down in flight, allowing for more accurate orbital insertions and manuevers.
 }
 
+// just use the stock method of pre-defining an action group
 @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
 	@description = #$description$ Just press the "Brakes" button (default "B") to do so.
@@ -22,56 +23,3 @@
 }
 
 // remark: could be generally patched into all parts, not just BDB parts
-
-
-// already existing with index 0, so add another ModuleBdbDefAGHelper with index 1
-// ModuleEngines
-// @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
-// {
-	// MODULE
-	// {
-		// name = ModuleBdbDefAGHelper
-		// actionModuleName = ModuleEngines
-		// actionModuleIndex = 1
-		// actionName = ShutdownAction
-		// actionDefaultActionGroup = Brakes
-	// }
-// }
-// ModuleEnginesFX
-// @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
-// {
-	// MODULE
-	// {
-		// name = ModuleBdbDefAGHelper
-		// actionModuleName = ModuleEnginesFX
-		// actionModuleIndex = 1
-		// actionName = ShutdownAction
-		// actionDefaultActionGroup = Brakes
-	// }
-// }
-
-// not existing yet, so add the ModuleBdbDefAGHelper with index 0
-// ModuleEngines
-// @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
-// {
-	// MODULE
-	// {
-		// name = ModuleBdbDefAGHelper
-		// actionModuleName = ModuleEngines
-		// actionModuleIndex = 0
-		// actionName = ShutdownAction
-		// actionDefaultActionGroup = Brakes
-	// }
-// }
-// ModuleEnginesFX
-// @PART[bluedog*,Bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
-// {
-	// MODULE
-	// {
-		// name = ModuleBdbDefAGHelper
-		// actionModuleName = ModuleEnginesFX
-		// actionModuleIndex = 0
-		// actionName = ShutdownAction
-		// actionDefaultActionGroup = Brakes
-	// }
-// }

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
@@ -1,9 +1,9 @@
-// Adds the action group "Brakes" to all solid fuel engines with the SafeSolid™ system, allows it to shutdown the engine quickly by pressing "B" (default keybinding for "Brakes")
+// Adds the action group "Brakes" to all solid fuel engines with the SafeSolidâ„¢ system, allows it to shutdown the engine quickly by pressing "B" (default keybinding for "Brakes")
 
-// If it's a SolidFuel engine which can be shut down, but got the SafeSolid™ not mentioned in the description yet, change this and mention it
+// If it's a SolidFuel engine which can be shut down, but got the SafeSolidâ„¢ not mentioned in the description yet, change this and mention it
 @PART[bluedog*,Bluedog*]:HAS[~description[*SafeSolid*],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
-	@description = #$description$ It features BDB's SafeSolid™ system, allowing the engine to be shut down in flight, allowing for more accurate orbital insertions and manuevers.
+	@description = #$description$ It features BDB's SafeSolidâ„¢ system, allowing the engine to be shut down in flight, allowing for more accurate orbital insertions and manuevers.
 }
 
 // already existing with index 0, so add another ModuleBdbDefAGHelper with index 1

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/SafeSolid shutdown with AG Brakes/SafeSolid shutdown with AG Brakes.cfg
@@ -1,59 +1,53 @@
 // Adds the action group "Brakes" to all solid fuel engines with the SafeSolid™ system, allows it to shutdown the engine quickly by pressing "B" (default keybinding for "Brakes")
 
 // already existing with index 0, so add another ModuleBdbDefAGHelper with index 1
-@PART]bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+// ModuleEngines
+@PART]bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
-	// ModuleEngines
-	@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
+	MODULE
 	{
-		MODULE
-		{
-			name = ModuleBdbDefAGHelper
-			actionModuleName = ModuleEngines
-			actionModuleIndex = 1
-			actionName = ShutdownEngine
-			actionDefaultActionGroup = Brakes
-		}
+		name = ModuleBdbDefAGHelper
+		actionModuleName = ModuleEngines
+		actionModuleIndex = 1
+		actionName = ShutdownEngine
+		actionDefaultActionGroup = Brakes
 	}
-	// ModuleEnginesFX
-	@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
+}
+// ModuleEnginesFX
+@PART]bluedog*]:HAS[#description[*SafeSolid*],@MODULE[ModuleBdbDefAGHelper]:HAS[~actionModuleIndex[1]],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+{
+	MODULE
 	{
-		MODULE
-		{
-			name = ModuleBdbDefAGHelper
-			actionModuleName = ModuleEnginesFX
-			actionModuleIndex = 1
-			actionName = ShutdownEngine
-			actionDefaultActionGroup = Brakes
-		}
+		name = ModuleBdbDefAGHelper
+		actionModuleName = ModuleEnginesFX
+		actionModuleIndex = 1
+		actionName = ShutdownEngine
+		actionDefaultActionGroup = Brakes
 	}
 }
 
 // not existing yet, so add the ModuleBdbDefAGHelper with index 0
-@PART]bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+// ModuleEngines
+@PART]bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
 {
-	// ModuleEngines
-	@MODULE[ModuleEngines]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
+	MODULE
 	{
-		MODULE
-		{
-			name = ModuleBdbDefAGHelper
-			actionModuleName = ModuleEngines
-			actionModuleIndex = 0
-			actionName = ShutdownEngine
-			actionDefaultActionGroup = Brakes
-		}
+		name = ModuleBdbDefAGHelper
+		actionModuleName = ModuleEngines
+		actionModuleIndex = 0
+		actionName = ShutdownEngine
+		actionDefaultActionGroup = Brakes
 	}
-	// ModuleEnginesFX
-	@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]
+}
+// ModuleEnginesFX
+@PART]bluedog*]:HAS[#description[*SafeSolid*],!MODULE[ModuleBdbDefAGHelper],@MODULE[ModuleEnginesFX]:HAS[#allowShutdown[?rue],@PROPELLANT[SolidFuel]]]:AFTER[zzzBluedog_DB]
+{
+	MODULE
 	{
-		MODULE
-		{
-			name = ModuleBdbDefAGHelper
-			actionModuleName = ModuleEnginesFX
-			actionModuleIndex = 0
-			actionName = ShutdownEngine
-			actionDefaultActionGroup = Brakes
-		}
+		name = ModuleBdbDefAGHelper
+		actionModuleName = ModuleEnginesFX
+		actionModuleIndex = 0
+		actionName = ShutdownEngine
+		actionDefaultActionGroup = Brakes
 	}
 }


### PR DESCRIPTION
Adds the action group "Brakes" to all solid fuel engines with the SafeSolid™ system, allows it to shutdown the engine quickly by pressing "B" (default keybinding for "Brakes")

Needs a little more testing, but here it is.