### PR TITLE
more mariner stuff

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/OGO_Extras/OGO_Ballast.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/OGO_Extras/OGO_Ballast.cfg
@@ -1,38 +1,14 @@
-@PART[bluedog_OGO_Core]:BEFORE[Bluedog_DB]
-{
-	node_stack_rear = 	0.0, 0.0, 0.224, 0.0, 0, 1, 0
-	node_stack_front = 	0.0, 0.0, -0.224, 0.0, 0, -1, 0
-	node_stack_left = 	-0.314, 0.0, 0.0, -1, 0.0, 0.0, 0
-	node_stack_right = 	0.314, 0.0, 0.0, 1, 0.0, 0.0, 0
-	
-	@MODULE[ModuleCommand]
-	{
-		defaultControlPointDisplayName = Forward
-		CONTROLPOINT
-		{
-			name = up
-			displayName = Up
-			orientation = -90,0,0
-		}
-		CONTROLPOINT
-		{
-			name = reverse
-			displayName = Reversed
-			orientation = 0,0,180
-		}
-	}
-}
-
+//adds a version of the OGO core filled with ballast.
 +PART[bluedog_OGO_Core]:NEEDS[CommunityResourcePack]:AFTER[Bluedog_DB]
 {
 	@name = bluedog_OGO_ballast
 	@title = HLR-OGO "Sansisco" Ballast
 	//description = 	description = Medium sized, rectangular probe bus for scientific and commercial satellites, originally design for our geophysical research satellite series. Includes the standard loadout of control processors, batteries, and other essential equipment.
 	@description =  This was a surplus probe core that had all its internal components removed and replaced by a block of lead for weighing down a submarine or balancing a spacecraft.
-	
+
 	@real_title = Box Ballast
 	@real_manufacturer = Goddard Space Flight Center
-	
+
 	//-vesselType
 	@category = Structural
 	//removes Modules

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/OGO_Extras/OGO_Rover.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/OGO_Extras/OGO_Rover.cfg
@@ -1,0 +1,25 @@
+//adds additional control points to the OGO core so it can be oriented in other directions such as for a rover or whatnot
+@PART[bluedog_OGO_Core]:BEFORE[Bluedog_DB]
+{
+	node_stack_rear = 	0.0, 0.0, 0.224, 0.0, 0, 1, 0
+	node_stack_front = 	0.0, 0.0, -0.224, 0.0, 0, -1, 0
+	node_stack_left = 	-0.314, 0.0, 0.0, -1, 0.0, 0.0, 0
+	node_stack_right = 	0.314, 0.0, 0.0, 1, 0.0, 0.0, 0
+
+	@MODULE[ModuleCommand]
+	{
+		defaultControlPointDisplayName = Forward
+		CONTROLPOINT
+		{
+			name = up
+			displayName = Up
+			orientation = -90,0,0
+		}
+		CONTROLPOINT
+		{
+			name = reverse
+			displayName = Reversed
+			orientation = 0,0,180
+		}
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/CommunityResourcePack/CRP sensors.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/CommunityResourcePack/CRP sensors.cfg
@@ -1,4 +1,4 @@
-//Patch made by Marcelo Silveira to replace the original generators in the BlueDog pack.
+//Patch made by Marcelo Silveira
 //	Resource types:  
 //	0 = Crustal		(Stuff you dig up)
 //	1 = Oceanic	(Stuff in the oceans)
@@ -204,3 +204,44 @@
 		ResourceName = Water
 	}
 }
+
+//Water
+@PART[bluedog_Ranger_Block2_GammaRaySpectrometer]:BEFORE[BlueDog_DB]:NEEDS[CommunityResourcePack]
+{
+	@description ^= :$: Can detect the composition of the liquid were it lands, it also can measure the ground water content.:
+	MODULE
+	{	name=ModuleBiomeScanner	}
+	MODULE
+	{	name=ModuleAsteroidAnalysis	}
+	MODULE
+	{
+		name=ModuleAnalysisResource
+		resourceName = Water
+	}
+
+	MODULE
+	{
+		name = ModuleResourceScanner
+		ScannerType = 0
+		ResourceName = Water
+		MaxAbundanceAltitude = 50
+		RequiresUnlock = false
+	}
+	MODULE
+	{
+		name = ModuleResourceScanner
+		ScannerType = 1
+		ResourceName = Water
+		MaxAbundanceAltitude = 12050
+		RequiresUnlock = false
+	}
+	MODULE
+	{
+		name = ModuleResourceScanner
+		ScannerType = 2
+		ResourceName = Water
+		MaxAbundanceAltitude = 48000
+		RequiresUnlock = false
+	}
+}
+

--- a/Gamedata/Bluedog_DB/Compatibility/OGO_Ballast.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/OGO_Ballast.cfg
@@ -1,0 +1,54 @@
+@PART[bluedog_OGO_Core]:BEFORE[Bluedog_DB]
+{
+	node_stack_rear = 	0.0, 0.0, 0.224, 0.0, 0, 1, 0
+	node_stack_front = 	0.0, 0.0, -0.224, 0.0, 0, -1, 0
+	node_stack_left = 	-0.314, 0.0, 0.0, -1, 0.0, 0.0, 0
+	node_stack_right = 	0.314, 0.0, 0.0, 1, 0.0, 0.0, 0
+	
+	@MODULE[ModuleCommand]
+	{
+		defaultControlPointDisplayName = Forward
+		CONTROLPOINT
+		{
+			name = up
+			displayName = Up
+			orientation = -90,0,0
+		}
+		CONTROLPOINT
+		{
+			name = reverse
+			displayName = Reversed
+			orientation = 0,0,180
+		}
+	}
+}
+
++PART[bluedog_OGO_Core]:NEEDS[CommunityResourcePack]:AFTER[Bluedog_DB]
+{
+	@name = bluedog_OGO_ballast
+	@title = HLR-OGO "Sansisco" Ballast
+	//description = 	description = Medium sized, rectangular probe bus for scientific and commercial satellites, originally design for our geophysical research satellite series. Includes the standard loadout of control processors, batteries, and other essential equipment.
+	@description =  This was a surplus probe core that had all its internal components removed and replaced by a block of lead for weighing down a submarine or balancing a spacecraft.
+	
+	@real_title = Box Ballast
+	@real_manufacturer = Goddard Space Flight Center
+	
+	//-vesselType
+	@category = Structural
+	//removes Modules
+	-MODULE[ModuleCommand]	{}
+	-MODULE[ModuleReactionWheel]	{}
+	-MODULE[ModuleSAS]	{}
+	-MODULE[ModuleKerbNetAccess]	{}
+	-MODULE[ModuleDataTransmitter]	{}
+	//removes battery
+	-RESOURCE[ElectricCharge]	{}
+	RESOURCE
+	{
+		name = LeadBallast
+		isTweakable = True
+		isVisible = True
+		ammount = 0
+		maxAmount = 280
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
@@ -171,58 +171,6 @@
 	}
 }
 
-@PART[bluedog_MOL_Camera]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
-{
-	MODULE
-	{
-		name = SCANsat
-		sensorType = 8  //2^3
-		fov = 3
-		min_alt = 5000
-		max_alt = 300000
-		best_alt = 122000
-		scanName = Visual inspection
-		animationName = Camera
-		RESOURCE
-		{
-			name = ElectricCharge
-			rate = 0.05
-		}
-	}
-
-	MODULE
-	{
-		name = SCANexperiment
-		experimentType = SCANsatBiomeAnomaly
-	}
-}
-//Wayfarer-2-ETS Radiometer || Mariner 2 Radiometer
-@PART[bluedog_Mariner2_Radiometer]:FOR[BlueDog_DB]:NEEDS[SCANsat]
-{
-	MODULE
-	{
-		name		= SCANsat
-		sensorType	= 1   //2^0
-		fov		= 3
-		min_alt		= 5000
-		max_alt		= 500000
-		best_alt	= 5000
-		scanName	= Mariner Radiometer
-		//animationName	= Collapse_Antenna
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.1
-		}
-	}
-
-	MODULE
-	{
-		name		= SCANexperiment
-		experimentType	= SCANsatAltimetryLoRes
-	}
-}
-
 //Cameras
 @PART[bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
@@ -319,6 +267,7 @@
 		RequiresUnlock = false
 	}
 }
+
 @PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
 	MODULE
@@ -387,34 +336,6 @@
 		ResourceName = Water
 		MaxAbundanceAltitude = 48000
 		RequiresUnlock = false
-	}
-}
-
-//
-//Wayfarer-2-ETS Radiometer || Mariner 2 Radiometer
-@PART[bluedog_Mariner2_Radiometer]:FOR[BlueDog_DB]:NEEDS[SCANsat]
-{
-	MODULE
-	{
-		name		= SCANsat
-		sensorType	= 1   //2^0
-		fov		= 3
-		min_alt		= 5000
-		max_alt		= 500000
-		best_alt	= 5000
-		scanName	= Mariner Radiometer
-		//animationName	= Collapse_Antenna
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.1
-		}
-	}
-
-	MODULE
-	{
-		name		= SCANexperiment
-		experimentType	= SCANsatAltimetryLoRes
 	}
 }
 
@@ -490,5 +411,30 @@
 			name	= ElectricCharge
 			rate	= 0.01
 		}
+	}
+}
+
+@PART[bluedog_MOL_Camera]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name = SCANsat
+		sensorType = 2  //2^1
+		fov = 2
+		min_alt = 5000
+		max_alt = 800000
+		best_alt = 750000
+		scanName = High-Res Optical Surveillance
+		animationName = deploy
+		RESOURCE
+			{
+				name = ElectricCharge
+				rate = 1.5
+			}
+	}
+	MODULE
+	{
+		name = SCANexperiment
+		experimentType = SCANsatAltimetryHiRes
 	}
 }

--- a/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
@@ -196,3 +196,299 @@
 		experimentType = SCANsatBiomeAnomaly
 	}
 }
+//Wayfarer-2-ETS Radiometer || Mariner 2 Radiometer
+@PART[bluedog_Mariner2_Radiometer]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name		= SCANsat
+		sensorType	= 1   //2^0
+		fov		= 3
+		min_alt		= 5000
+		max_alt		= 500000
+		best_alt	= 5000
+		scanName	= Mariner Radiometer
+		//animationName	= Collapse_Antenna
+		RESOURCE
+		{
+			name	= ElectricCharge
+			rate	= 0.1
+		}
+	}
+
+	MODULE
+	{
+		name		= SCANexperiment
+		experimentType	= SCANsatAltimetryLoRes
+	}
+}
+
+//Cameras
+@PART[bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name = SCANsat
+		sensorType = 8  //2^3
+		fov = 3
+		min_alt = 50
+		max_alt = 150000
+		best_alt = 21000
+		scanName = Visual inspection
+	//	animationName = Camera
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.05
+		}
+	}
+
+	MODULE
+	{
+		name = SCANexperiment
+		experimentType = SCANsatBiomeAnomaly
+	}
+}
+
+//Burke-2-RAD Radar Altimeter
+@PART[bluedog_Ranger_Block2_RadarAltimeter]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name		= SCANsat
+		sensorType	= 1   //2^0
+		fov		= 3
+		min_alt		= 3000
+		max_alt		= 600000
+		best_alt	= 5000
+		scanName	= Ranger radio altimeter
+		//animationName	= Collapse_Antenna
+		RESOURCE
+		{
+			name	= ElectricCharge
+			rate	= 0.1
+		}
+	}
+
+	MODULE
+	{
+		name		= SCANexperiment
+		experimentType	= SCANsatAltimetryLoRes
+	}
+}
+
+//Anomaly detectors
+@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device2,bluedog_Ranger_Block1_ElectroAnalyzer_Device1]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name		= SCANsat
+		sensorType	= 32   //2^5
+		fov		= 1
+		min_alt		= 0
+		max_alt		= 20500
+		best_alt	= 0
+		scanName	= Anomaly scanner
+
+		RESOURCE
+		{
+			name	= ElectricCharge
+			rate	= 0.01
+		}
+	}
+}
+
+//Lyman-Alpha UV Telescope
+//CA-LUV Ultraviolet Spectrometer|CAE-SC-VIS Vorona Imaging System
+@PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:BEFORE[BlueDog_DB]:NEEDS[CommunityResourcePack]
+{
+	MODULE
+	{
+		name = ModuleResourceScanner
+		ScannerType = 0
+		ResourceName = Substrate
+		MaxAbundanceAltitude = 55000
+		RequiresUnlock = false
+	}
+	MODULE
+	{
+		name = ModuleResourceScanner
+		ScannerType = 0
+		ResourceName = Minerals
+		MaxAbundanceAltitude = 72500
+		RequiresUnlock = false
+	}
+}
+@PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name = ModuleSCANresourceScanner
+		sensorType = 98304//Substrate, Minerals
+		fov = 3
+		min_alt = 5000
+		max_alt = 125000
+		best_alt = 25000
+		scanName = Ultraviolet Scan
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.04
+		}
+	}
+	MODULE
+	{
+		name = SCANresourceDisplay
+		sensorType = 128
+		ResourceName = MetallicOre
+	}
+	MODULE
+	{
+		name = SCANresourceDisplay
+		sensorType = 256
+		ResourceName = Ore
+	}
+}
+
+//Water
+@PART[bluedog_Ranger_Block2_GammaRaySpectrometer]:BEFORE[BlueDog_DB]:NEEDS[CommunityResourcePack]
+{
+	@description ^= :$: Can detect the composition of the liquid were it lands, it also can measure the ground water content.:
+	MODULE
+	{	name=ModuleBiomeScanner	}
+	MODULE
+	{	name=ModuleAsteroidAnalysis	}
+	MODULE
+	{
+		name=ModuleAnalysisResource
+		resourceName = Water
+	}
+
+	MODULE
+	{
+		name = ModuleResourceScanner
+		ScannerType = 0
+		ResourceName = Water
+		MaxAbundanceAltitude = 50
+		RequiresUnlock = false
+	}
+	MODULE
+	{
+		name = ModuleResourceScanner
+		ScannerType = 1
+		ResourceName = Water
+		MaxAbundanceAltitude = 12050
+		RequiresUnlock = false
+	}
+	MODULE
+	{
+		name = ModuleResourceScanner
+		ScannerType = 2
+		ResourceName = Water
+		MaxAbundanceAltitude = 48000
+		RequiresUnlock = false
+	}
+}
+
+//
+//Wayfarer-2-ETS Radiometer || Mariner 2 Radiometer
+@PART[bluedog_Mariner2_Radiometer]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name		= SCANsat
+		sensorType	= 1   //2^0
+		fov		= 3
+		min_alt		= 5000
+		max_alt		= 500000
+		best_alt	= 5000
+		scanName	= Mariner Radiometer
+		//animationName	= Collapse_Antenna
+		RESOURCE
+		{
+			name	= ElectricCharge
+			rate	= 0.1
+		}
+	}
+
+	MODULE
+	{
+		name		= SCANexperiment
+		experimentType	= SCANsatAltimetryLoRes
+	}
+}
+
+//Cameras
+@PART[bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name = SCANsat
+		sensorType = 8  //2^3
+		fov = 3
+		min_alt = 50
+		max_alt = 150000
+		best_alt = 21000
+		scanName = Visual inspection
+	//	animationName = Camera
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.05
+		}
+	}
+
+	MODULE
+	{
+		name = SCANexperiment
+		experimentType = SCANsatBiomeAnomaly
+	}
+}
+
+//Burke-2-RAD Radar Altimeter
+@PART[bluedog_Ranger_Block2_RadarAltimeter]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name		= SCANsat
+		sensorType	= 1   //2^0
+		fov		= 3
+		min_alt		= 3000
+		max_alt		= 600000
+		best_alt	= 5000
+		scanName	= Ranger radio altimeter
+		//animationName	= Collapse_Antenna
+		RESOURCE
+		{
+			name	= ElectricCharge
+			rate	= 0.1
+		}
+	}
+
+	MODULE
+	{
+		name		= SCANexperiment
+		experimentType	= SCANsatAltimetryLoRes
+	}
+}
+
+//Anomaly detectors
+@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device2,bluedog_Ranger_Block1_ElectroAnalyzer_Device1]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+{
+	MODULE
+	{
+		name		= SCANsat
+		sensorType	= 32   //2^5
+		fov		= 1
+		min_alt		= 0
+		max_alt		= 20500
+		best_alt	= 0
+		scanName	= Anomaly scanner
+
+		RESOURCE
+		{
+			name	= ElectricCharge
+			rate	= 0.01
+		}
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/USI-LS/bluedog_Gemini_1p5mDepot.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/USI-LS/bluedog_Gemini_1p5mDepot.cfg
@@ -1,0 +1,100 @@
+PART:NEEDS[USILifeSupport]
+{
+	name = bluedog_Gemini_1p5mDepot
+	module = Part
+	author = CobaltWolf
+MODEL
+{
+	model = Bluedog_DB/Parts/Gemini/bluedog_Gemini_1p5mShortSegment
+}
+	rescaleFactor = 1
+	node_stack_top = 0.0, 0.8, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.8, 0.0, 0.0, -1.0, 0.0, 2
+	CrewCapacity = 1
+	TechRequired = survivability
+	entryCost = 2500
+	cost = 700
+	category = Utility
+	subcategory = 0
+	title = LMSS-OCS 1.5m Space Station Depot
+	manufacturer = Bluedog Design Bureau
+	description = A small 1.5m crew can filled with only batteries and shelves for supplies.
+	real_title = GMSS 1.5m One Room Space Space Station Logistics Module
+	real_manufacturer = McDonnell Aircraft
+//	real_description = Core building block of the Modular Gemini Space Station, this module contains a single pressurized volume with associated support equipment. Provides enough space for two crew members.
+	attachRules = 1,0,1,1,0
+	mass = 0.910
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.3
+	angularDrag = 2
+	crashTolerance = 6
+	breakingForce = 72
+	breakingTorque = 72
+	maxTemp = 1000
+	skinMaxTemp = 2200
+//	vesselType = Ship
+	bulkheadProfiles = size1p2
+
+	tags = MOL MOS Gemini Leo base cabin (can outpost passenger statio tour tuna 1.5 cck-lifesupport
+
+	INTERNAL
+	{
+		name = crewCabinInternals
+	}
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 2000
+		maxAmount = 2000
+	}
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 1500
+		maxAmount = 1500
+	}
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 150
+	}
+
+		MODULE
+	{
+		name = ModuleColorChanger
+		shaderProperty = _EmissiveColor
+		animRate = 0.8
+		animState = false
+		useRate = true
+		toggleInEditor = true
+		toggleInFlight = true
+		toggleInFlight = true
+		unfocusedRange = 5
+		toggleName = Toggle Lights
+		eventOnName = Lights On
+		eventOffName = Lights Off
+		toggleAction = True
+		defaultActionGroup = Light
+		redCurve
+		{
+			key = 0 0 0 3
+			key = 1 1 0 0
+		}
+		greenCurve
+		{
+			key = 0 0 0 1
+			key = 1 1 1 0
+		}
+		blueCurve
+		{
+			key = 0 0 0 0
+			key = 1 0.7 1.5 0
+		}
+		alphaCurve
+		{
+			key = 0 1
+		}
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/USI-LS/bluedog_Gemini_1p875mDepot.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/USI-LS/bluedog_Gemini_1p875mDepot.cfg
@@ -1,0 +1,307 @@
+//short version
+PART:NEEDS[USILifeSupport]
+{
+	name = bluedog_Gemini_OneRoomDepot
+	module = Part
+	author = CobaltWolf
+MODEL
+{
+	model = Bluedog_DB/Parts/Gemini/bluedog_Gemini_OneRoomStationModule
+}
+	rescaleFactor = 1
+	node_stack_top = 0.0, 1, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -1, 0.0, 0.0, -1.0, 0.0, 2
+	CrewCapacity = 1
+	TechRequired = basicScience
+	entryCost = 4500
+	cost = 1400
+	category = Utility
+	subcategory = 0
+	title = LMSS-ORS 1.875m One-Room Space Station Depot
+	manufacturer = Bluedog Design Bureau
+	description = Core building block of the Leo Modular Space Station, this module contains a single pressurized volume without any equipment, only batteries and shelves for supplies.
+	real_title = GMSS 1.875m One Room Space Space Logistics Module
+	real_manufacturer = McDonnell Aircraft
+	real_description = Core building block of the Modular Gemini Space Station, this module contains a single pressurized volume without any equipment, only batteries and shelves for supplies.
+	attachRules = 1,0,1,1,0
+	mass = 1.8
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.3
+	angularDrag = 2
+	crashTolerance = 6
+	breakingForce = 112
+	breakingTorque = 112
+	maxTemp = 1000
+	skinMaxTemp = 2200
+//	vesselType = Ship
+	bulkheadProfiles = size1p5
+
+	tags = MOL MOS Gemini Leo base cabin (can outpost passenger statio tour tuna cck-lifesupport
+
+	INTERNAL
+	{
+		name = crewCabinInternals
+	}
+
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 2000
+		maxAmount = 2000
+	}
+
+	RESOURCE
+	{
+		name = Supplies
+		amount = 0
+		maxAmount = 2500
+	}
+
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 250
+	}
+
+	MODULE
+	{
+		name = ModuleColorChanger
+		shaderProperty = _EmissiveColor
+		animRate = 0.8
+		animState = false
+		useRate = true
+		toggleInEditor = true
+		toggleInFlight = true
+		toggleInFlight = true
+		unfocusedRange = 5
+		toggleName = Toggle Lights
+		eventOnName = Lights On
+		eventOffName = Lights Off
+		toggleAction = True
+		defaultActionGroup = Light
+		redCurve
+		{
+			key = 0 0 0 3
+			key = 1 1 0 0
+		}
+		greenCurve
+		{
+			key = 0 0 0 1
+			key = 1 1 1 0
+		}
+		blueCurve
+		{
+			key = 0 0 0 0
+			key = 1 0.7 1.5 0
+		}
+		alphaCurve
+		{
+			key = 0 1
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = meshSwitchWindows
+		switcherDescription = Windows
+		affectDragCubes = False
+		affectFARVoxels = False
+		SUBTYPE
+		{
+			name = Four
+			transform = FourWindows
+		}
+		SUBTYPE
+		{
+			name = Three
+			transform = ThreeWindows
+		}
+		SUBTYPE
+		{
+			name = Two
+			transform = TwoWindows
+		}
+		SUBTYPE
+		{
+			name = Two (Alt)
+			transform = TwoWindowsAlt
+		}
+		SUBTYPE
+		{
+			name = One
+			transform = OneWindow
+		}
+		SUBTYPE
+		{
+			name = None
+			transform = NoWindows
+		}
+	}
+
+}
+
+//Long version
+PART:NEEDS[USILifeSupport]
+{
+	name = bluedog_Gemini_TwoRoomStationDepot
+	module = Part
+	author = CobaltWolf
+MODEL
+{
+	model = Bluedog_DB/Parts/Gemini/bluedog_Gemini_TwoRoomStationModule
+}
+	rescaleFactor = 1
+	node_stack_top = 0.0, 1.5, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -1.5, 0.0, 0.0, -1.0, 0.0, 2
+	CrewCapacity = 1
+	TechRequired = spaceExploration
+	entryCost = 6000
+	cost = 2100
+	category = Utility
+	subcategory = 0
+	title = LMSS-TRS 1.875m Two-Room Space Depot
+	manufacturer = Bluedog Design Bureau
+	description = Core building block of the Leo Modular Space Station, this module contains a large pressurized volume split into two "rooms",  without any equipment, only batteries and shelves for supplies.
+	real_title = GMSS-TRS 1.875m Two-Room Space Station Logistics Module
+	real_manufacturer = McDonnell Aircraft
+	real_description =  Core building block of the Modular Gemini Space Station, this module contains a large pressurized volume split into two "rooms", without any equipment, only batteries and shelves for supplies.
+	attachRules = 1,0,1,1,0
+	mass = 2.3
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.3
+	angularDrag = 2
+	crashTolerance = 6
+	breakingForce = 112
+	breakingTorque = 112
+	maxTemp = 1000
+	skinMaxTemp = 2200
+	vesselType = Ship
+	bulkheadProfiles = size1p5
+
+	tags = base cabin (can outpost passenger statio tour tuna MOL MOS Gemini Leo cck-lifesupport
+
+	INTERNAL
+	{
+		name = crewCabinInternals
+	}
+
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 2000
+		maxAmount = 2000
+	}
+
+	RESOURCE
+	{
+		name = Supplies
+		amount = 0
+		maxAmount = 3600
+	}
+
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 360
+	}
+	MODULE
+	{
+		name = ModuleColorChanger
+		shaderProperty = _EmissiveColor
+		animRate = 0.8
+		animState = false
+		useRate = true
+		toggleInEditor = true
+		toggleInFlight = true
+		toggleInFlight = true
+		unfocusedRange = 5
+		toggleName = Toggle Lights
+		eventOnName = Lights On
+		eventOffName = Lights Off
+		toggleAction = True
+		defaultActionGroup = Light
+		redCurve
+		{
+			key = 0 0 0 3
+			key = 1 1 0 0
+		}
+		greenCurve
+		{
+			key = 0 0 0 1
+			key = 1 1 1 0
+		}
+		blueCurve
+		{
+			key = 0 0 0 0
+			key = 1 0.7 1.5 0
+		}
+		alphaCurve
+		{
+			key = 0 1
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = meshSwitchWindows
+		switcherDescription = Windows
+		affectDragCubes = False
+		affectFARVoxels = False
+		SUBTYPE
+		{
+			name = Eight
+			transform = EightWindows
+		}
+		SUBTYPE
+		{
+			name = Seven
+			transform = SevenWindows
+		}
+		SUBTYPE
+		{
+			name = Six
+			transform = SixWindows
+		}
+		SUBTYPE
+		{
+			name = Four
+			transform = FourWindows
+		}
+		SUBTYPE
+		{
+			name = Four (Alt)
+			transform = FourWindows_Alt
+		}
+		SUBTYPE
+		{
+			name = Three
+			transform = ThreeWindows
+		}
+		SUBTYPE
+		{
+			name = Two
+			transform = TwoWindows
+		}
+		SUBTYPE
+		{
+			name = Two (Alt)
+			transform = TwoWindows_Alt
+		}
+		SUBTYPE
+		{
+			name = One
+			transform = OneWindow
+		}
+		SUBTYPE
+		{
+			name = None
+			transform = NoWindows
+		}
+	}
+}


### PR DESCRIPTION
- three new parts IF the user has USI life support, just adapted the MOL 1.5m and 1.875m "room" parts so they behave as a logistic module. In the future I might change it to work with SSPX

- Mariner sensors and scanners

- adds more nodes to OGO probe (kinda like the vanilla rover body) and creates an empty version for ballast because reasons