### PR TITLE
adjust bottom nodes on delta p/k fairing adaptors

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/ProceduralFairings/bdb_pf.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/ProceduralFairings/bdb_pf.cfg
@@ -117,6 +117,15 @@
 	@node_stack_bottom2[1,,] -= #$tempShift$
 }
 
+@PART[bluedog_Delta_Miniskirt_1p5m_PF]:FOR[Jso_Bdb_PF]:NEEDS[ProceduralFairings]
+{
+	%node_stack_bottom2 = 0.0, -0.279, 0.0, 0.0, -1.0, 0.0
+}
+@PART[bluedog_Delta_Miniskirt_1p875m_PF]:FOR[Jso_Bdb_PF]:NEEDS[ProceduralFairings]
+{
+	%node_stack_bottom2 = 0.0, -0.344, 0.0, 0.0, -1.0, 0.0
+}
+
 +PART[bluedog_Saturn_3125mFairingBase_PF]:FOR[Jso_Bdb_PF]:NEEDS[ProceduralFairings]
 {
 	@name ^= :$:_adaptor:


### PR DESCRIPTION
Just manually tuned the bottom nodes to match the non-PF versions #793 