### PR TITLE
Add reverse control point

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/HullcamVDS/hullcam_Science.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/HullcamVDS/hullcam_Science.cfg
@@ -54,3 +54,101 @@
 		cameraMode = 6
 	}
 }
+//Ranger Block 3 Television Camera System
+@PART[bluedog_Ranger_Block3_TVSystem]:NEEDS[HullCameraVDS]
+{
+	@description ^= :$: Live feed by Hullcam VDS.:
+	MODULE
+	{
+	    name = MuMechModuleHullCameraZoom
+	    cameraName = RangerCam
+	    cameraForward = -.7071, -0.7071, 0
+	    cameraUp = -0.772, -0.635, 0
+	    cameraPosition = -0.1, 0.168, 0
+	    cameraFoVMax = 80
+	    cameraFoVMin = 5
+		cameraMode = 5
+	}
+}
+
+//Lunar Orbiter
+@PART[bluedog_LunarOrbiter_Camera]:NEEDS[HullCameraVDS]
+{
+	@description ^= :$: Live feed by Hullcam VDS.:
+	MODULE
+	{
+	    name = MuMechModuleHullCameraZoom
+	    cameraName = LunarCam
+	    cameraForward = 0, 0, -1
+	    cameraUp = 0, -1, 0
+	    cameraPosition = 0, 0, -0.3
+	    cameraFoVMax = 80
+	    cameraFoVMin = 20
+		cameraMode = 4
+	}
+}
+
+//Keyhole KH-1
+@PART[bluedog_Keyhole_Camera_KH1]:NEEDS[HullCameraVDS]
+{
+	@description ^= :$: Live feed by Hullcam VDS.:
+	MODULE
+	{
+	    name = MuMechModuleHullCameraZoom
+	    cameraName = KeyholeCam
+	    cameraForward = 0, 0, 1
+	    cameraUp = 0, 1, 0
+	    cameraPosition = 0, -0.05, 0.35
+	    cameraFoVMax = 80
+	    cameraFoVMin = 20
+		cameraMode = 4	//B&W
+	}
+}
+//Keyhole KH-4
+@PART[bluedog_Keyhole_Camera_KH4]:NEEDS[HullCameraVDS]
+{
+	@description ^= :$: Live feed by Hullcam VDS.:
+	MODULE
+	{
+	    name = MuMechModuleHullCameraZoom
+	    cameraName = KeyholeCam
+	    cameraForward = 0, 0, 1
+	    cameraUp = 0, 1, 0
+	    cameraPosition = 0, 0.18, 0.22
+	    cameraFoVMax = 80
+	    cameraFoVMin = 20
+		cameraMode = 6
+	}
+}
+//Keyhole KH-4B
+@PART[bluedog_Keyhole_Camera_KH4B]:NEEDS[HullCameraVDS]
+{
+	@description ^= :$: Live feed by Hullcam VDS.:
+	MODULE
+	{
+	    name = MuMechModuleHullCameraZoom
+	    cameraName = KeyholeCam
+	    cameraForward = 0, 0, 1
+	    cameraUp = 0, 1, 0
+	    cameraPosition = 0, 0, 0.3
+	    cameraFoVMax = 60
+	    cameraFoVMin = 2
+		cameraMode = 6
+	}
+}
+//Keyhole KH-7 Gambit
+@PART[bluedog_Keyhole_Camera_KH7]:NEEDS[HullCameraVDS]
+{
+	@description ^= :$: Live feed by Hullcam VDS.:
+	MODULE
+	{
+	    name = MuMechModuleHullCameraZoom
+	    cameraName = GambitCam
+	    cameraForward = 0, 0, 1
+	    cameraUp = 0, 1, 0
+	    cameraPosition = 0, 0.80, -0.160
+	    cameraFoVMax = 60
+	    cameraFoVMin = 0.2
+		cameraMode = 6
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
@@ -1,6 +1,5 @@
 @PART[Bluedog_Geiger]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Uraninite and Monazite scanner</color>:
     MODULE
     {
         name = ModuleSCANresourceScanner
@@ -24,10 +23,14 @@
         ResourceName = Uraninite
     }
 }
+@PART[Bluedog_Geiger]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+		@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Uraninite and Monazite scanner</color>:
+}
 
 @PART[bluedog_foldingMag,bluedog_Pioneer6_Boom_Mag,bluedog_AIMP_Magnetometer,bluedog_Helios_Magnetometer]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore, Metallic Ore, Rare and Exotic Metals scanner</color>:
+
 	MODULE
 	{
 		name = ModuleSCANresourceScanner
@@ -68,9 +71,15 @@
 		ResourceName = ExoticMinerals
 	}
 }
+@PART[bluedog_foldingMag,bluedog_Pioneer6_Boom_Mag,bluedog_AIMP_Magnetometer,bluedog_Helios_Magnetometer]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+		@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore, Metallic Ore, Rare and Exotic Metals scanner</color>:
+}
+
+
 @PART[bluedog_Biosat_Magnetometer]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore and Metallic Ore scanner</color>:
+
 	MODULE
 	{
 		name = ModuleSCANresourceScanner
@@ -99,9 +108,13 @@
 		ResourceName = Ore
 	}
 }
+@PART[bluedog_Biosat_Magnetometer]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+		@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore and Metallic Ore scanner</color>:
+}
+
 @PART[bluedog_cameraLowTech]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
 	MODULE
 	{
 		name = SCANsat
@@ -125,10 +138,13 @@
 		experimentType = SCANsatBiomeAnomaly
 	}
 }
+@PART[bluedog_cameraLowTech]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
+}
 
 @PART[bluedog_cameraMidTech]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
 	MODULE
 	{
 		name = SCANsat
@@ -152,10 +168,14 @@
 		experimentType = SCANsatBiomeAnomaly
 	}
 }
+@PART[bluedog_cameraMidTech]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
+}
+
 
 @PART[bluedog_cameraHighTech]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Multispectral scanner (Biome and Anomaly)</color>:
 	MODULE
 	{
 		name = SCANsat
@@ -179,10 +199,14 @@
 		experimentType = SCANsatBiomeAnomaly
 	}
 }
+@PART[bluedog_cameraHighTech]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
+}
 
 @PART[bluedog_IRspec]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Multispectral scanner (Biome and Anomaly)</color>:
+
 	MODULE
 	{
 		name = SCANsat
@@ -205,12 +229,16 @@
 		name = SCANexperiment
 		experimentType = SCANsatBiomeAnomaly
 	}
+}
+@PART[bluedog_IRspec]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Multispectral scanner (Biome and Anomaly)</color>:
 }
 
 //Cameras
 @PART[bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
+
 	MODULE
 	{
 		name = SCANsat
@@ -234,11 +262,15 @@
 		experimentType = SCANsatBiomeAnomaly
 	}
 }
+@PART[bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
+}
 
 //Burke-2-RAD Radar Altimeter
 @PART[bluedog_Ranger_Block2_RadarAltimeter]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Basic altimetry scanner</color>:
+
 	MODULE
 	{
 		name		= SCANsat
@@ -264,11 +296,15 @@
 
   !MODULE[DMModuleScienceAnimateGeneric] {}
 }
+@PART[bluedog_Ranger_Block2_RadarAltimeter]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Basic altimetry scanner</color>:
+}
+
 
 //Anomaly detectors
 @PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device2,bluedog_Ranger_Block1_ElectroAnalyzer_Device1]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Anomaly scanner</color>:
 	MODULE
 	{
 		name		= SCANsat
@@ -286,31 +322,16 @@
 		}
 	}
 }
-
-//Lyman-Alpha UV Telescope
-@PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:BEFORE[BlueDog_DB]:NEEDS[CommunityResourcePack,!SCANsat]
+@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device2,bluedog_Ranger_Block1_ElectroAnalyzer_Device1]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
 {
-	MODULE
-	{
-		name = ModuleResourceScanner
-		ScannerType = 0
-		ResourceName = Substrate
-		MaxAbundanceAltitude = 55000
-		RequiresUnlock = false
-	}
-	MODULE
-	{
-		name = ModuleResourceScanner
-		ScannerType = 0
-		ResourceName = Minerals
-		MaxAbundanceAltitude = 72500
-		RequiresUnlock = false
-	}
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Anomaly scanner</color>:
 }
 
+
+//Lyman-Alpha UV Telescope
 @PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore, Substrate and Minerals scanner</color>:
+
 	MODULE
 	{
 		name = ModuleSCANresourceScanner
@@ -339,15 +360,24 @@
 		ResourceName = Ore
 	}
 }
+@PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore, Substrate and Minerals scanner</color>:
+}
+
 
 //Water
 @PART[bluedog_Ranger_Block2_GammaRaySpectrometer]:BEFORE[BlueDog_DB]:NEEDS[CommunityResourcePack]
 {
-	@description ^= :$: Can detect the composition of the liquid were it lands, it also can measure the ground water content.:
+
 	MODULE
-	{	name=ModuleBiomeScanner	}
+	{
+		name=ModuleBiomeScanner
+	}
 	MODULE
-	{	name=ModuleAsteroidAnalysis	}
+	{
+		name=ModuleAsteroidAnalysis
+	}
 	MODULE
 	{
 		name=ModuleAnalysisResource
@@ -379,11 +409,16 @@
 		RequiresUnlock = false
 	}
 }
+@PART[bluedog_Ranger_Block2_GammaRaySpectrometer]:AFTER[zzzBlueDog_DB]:NEEDS[CommunityResourcePack]
+{
+	@description ^= :$: Can detect the composition of the liquids on the surface, it also can measure the ground water content.:
+}
+
 
 //Cameras
 @PART[bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Water scanner</color>:
+
 	MODULE
 	{
 		name = SCANsat
@@ -407,6 +442,12 @@
 		experimentType = SCANsatBiomeAnomaly
 	}
 }
+@PART[bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem]:AFTER[zzzBlueDog_DB]:NEEDS[SCANsat]
+{
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Water scanner</color>:
+}
+
+
 //////////////////////Special configs for spy sats//////////////////////
 
 //Film based low resolution scanning
@@ -480,13 +521,13 @@
 //
 @PART[bluedog_MOL_Camera,bluedog_Keyhole_Camera_KH7,bluedog_Keyhole_Camera_KH8]:AFTER[zzzBluedog_DB]:NEEDS[SCANsat]//AFTER zzzBluedog_DB so as not to interfere with realnames patches which might change the description
 {
-  @description ^= :$: *SCANSAT - This camera is capable of performing high resolution altimetry scans. However, it also uses raw film stock as a resource in addition to EC. Multiple launches may be needed in some instances. Unlike Synthetic Aperture Radar based high resolution scanning systems which are deployed in high orbits, this optical scanner needs to be deployed in low orbit* :
+  @description ^= :(.)$:$0\n<#7FD5FF> SCANSAT - This camera is capable of performing high resolution altimetry scans. However, it also uses raw film stock as a resource in addition to EC. Multiple launches may be needed in some instances. Unlike Synthetic Aperture Radar based high resolution scanning systems which are deployed in high orbits, this optical scanner needs to be deployed in low orbit </color>:
 }
 
 //
 @PART[bluedog_Keyhole_Camera_KH1,bluedog_Keyhole_Camera_KH4,bluedog_Keyhole_Camera_KH4B]:AFTER[zzzBluedog_DB]:NEEDS[SCANsat]//AFTER zzzBluedog_DB so as not to interfere with realnames patches which might change the description
 {
-  @description ^= :$: *SCANSAT - This camera is capable of performing low resolution altimetry scans. However, it also uses raw film stock as a resource in addition to EC. Multiple launches may be needed in some instances* :
+  @description ^= :(.)$:$0\n<#7FD5FF> SCANSAT - This camera is capable of performing low resolution altimetry scans. However, it also uses raw film stock as a resource in addition to EC. Multiple launches may be needed in some instances* </color>:
 }
 
 //add film resources

--- a/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
@@ -1,5 +1,6 @@
 @PART[Bluedog_Geiger]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Uraninite and Monazite scanner</color>:
     MODULE
     {
         name = ModuleSCANresourceScanner
@@ -14,7 +15,7 @@
             name = ElectricCharge
             rate = 0.04
         }
-    }﻿
+    }
 
     MODULE
     {
@@ -24,8 +25,9 @@
     }
 }
 
-@PART[bluedog_foldingMag,bluedog_Pioneer6_Boom_Mag]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
+@PART[bluedog_foldingMag,bluedog_Pioneer6_Boom_Mag,bluedog_AIMP_Magnetometer,bluedog_Helios_Magnetometer]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore, Metallic Ore, Rare and Exotic Metals scanner</color>:
 	MODULE
 	{
 		name = ModuleSCANresourceScanner
@@ -66,9 +68,40 @@
 		ResourceName = ExoticMinerals
 	}
 }
-
+@PART[bluedog_Biosat_Magnetometer]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
+{
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore and Metallic Ore scanner</color>:
+	MODULE
+	{
+		name = ModuleSCANresourceScanner
+		sensorType = 384 // MetallicOre Ore
+		fov = 4
+		min_alt = 5000
+		max_alt = 120000
+		best_alt = 100000
+		scanName = Magnetic Scan
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.04
+		}
+	}
+	MODULE
+	{
+		name = SCANresourceDisplay
+		sensorType = 128
+		ResourceName = MetallicOre
+	}
+	MODULE
+	{
+		name = SCANresourceDisplay
+		sensorType = 256
+		ResourceName = Ore
+	}
+}
 @PART[bluedog_cameraLowTech]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
 	MODULE
 	{
 		name = SCANsat
@@ -95,6 +128,7 @@
 
 @PART[bluedog_cameraMidTech]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
 	MODULE
 	{
 		name = SCANsat
@@ -121,6 +155,7 @@
 
 @PART[bluedog_cameraHighTech]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Multispectral scanner (Biome and Anomaly)</color>:
 	MODULE
 	{
 		name = SCANsat
@@ -147,6 +182,7 @@
 
 @PART[bluedog_IRspec]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Multispectral scanner (Biome and Anomaly)</color>:
 	MODULE
 	{
 		name = SCANsat
@@ -174,6 +210,7 @@
 //Cameras
 @PART[bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome scanner</color>:
 	MODULE
 	{
 		name = SCANsat
@@ -201,6 +238,7 @@
 //Burke-2-RAD Radar Altimeter
 @PART[bluedog_Ranger_Block2_RadarAltimeter]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Basic altimetry scanner</color>:
 	MODULE
 	{
 		name		= SCANsat
@@ -230,6 +268,7 @@
 //Anomaly detectors
 @PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device2,bluedog_Ranger_Block1_ElectroAnalyzer_Device1]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Anomaly scanner</color>:
 	MODULE
 	{
 		name		= SCANsat
@@ -249,8 +288,7 @@
 }
 
 //Lyman-Alpha UV Telescope
-//CA-LUV Ultraviolet Spectrometer|CAE-SC-VIS Vorona Imaging System
-@PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:BEFORE[BlueDog_DB]:NEEDS[CommunityResourcePack]
+@PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:BEFORE[BlueDog_DB]:NEEDS[CommunityResourcePack,!SCANsat]
 {
 	MODULE
 	{
@@ -272,6 +310,7 @@
 
 @PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:AFTER[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore, Substrate and Minerals scanner</color>:
 	MODULE
 	{
 		name = ModuleSCANresourceScanner
@@ -344,6 +383,7 @@
 //Cameras
 @PART[bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
+	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Water scanner</color>:
 	MODULE
 	{
 		name = SCANsat
@@ -367,28 +407,6 @@
 		experimentType = SCANsatBiomeAnomaly
 	}
 }
-
-//Anomaly detectors
-@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device2,bluedog_Ranger_Block1_ElectroAnalyzer_Device1]:FOR[BlueDog_DB]:NEEDS[SCANsat]
-{
-	MODULE
-	{
-		name		= SCANsat
-		sensorType	= 32   //2^5
-		fov		= 1
-		min_alt		= 0
-		max_alt		= 20500
-		best_alt	= 0
-		scanName	= Anomaly scanner
-
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.01
-		}
-	}
-}
-
 //////////////////////Special configs for spy sats//////////////////////
 
 //Film based low resolution scanning

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/LunarOrbiter/bluedog_LunarOrbiter_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/LunarOrbiter/bluedog_LunarOrbiter_Core.cfg
@@ -50,10 +50,11 @@ PART
 	subcategory = 0
 	title = Codac-PCT "Kreuznach" Probe Core
 	manufacturer = Bluedog Design Bureau
-	description = A unique probe core design, the avionics and control systems are built around a truss structure. The inside of the truss is left open for experiments like cameras. The outer ring can be be fitted with folding solar panels and communications equipment.
+	description = A unique probe core design, the avionics and control systems are built around a truss structure. The inside of the truss is left open for experiments like cameras. The outer ring can be be fitted with folding solar panels and communications equipment. Typically launched upside down inside a Belle upper stage. The control direction can be reversed to assist with this and can also be changed back in flight.
 
 	real_title = Lunar Orbiter Probe Core
 	real_manufacturer = Boeing
+	real_description = A unique probe core design, the Lunar Orbiter avionics and control systems are built around a truss structure. The inside of the truss is left open for experiments like cameras. The outer ring can be be fitted with folding solar panels and communications equipment. Typically launched upside down inside an Agena upper stage. The control direction can be reversed to assist with this and can also be changed back in flight.
 
 	attachRules = 1,0,1,1,0
 	mass = 0.22

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/LunarOrbiter/bluedog_LunarOrbiter_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/LunarOrbiter/bluedog_LunarOrbiter_Core.cfg
@@ -82,6 +82,14 @@ PART
 			rate = 0.01
 		}
 		hasHibernation = True
+		hibernationMultiplier = 0.25
+		defaultControlPointDisplayName =  Forward
+		CONTROLPOINT
+		{
+			name = reverse
+			displayName = Reversed
+			orientation = 0,0,180
+		}
 	}
 
 	RESOURCE


### PR DESCRIPTION
Add a control point option so the Lunar orbiter can be launched in its real orientation (facing down) more easily. It can be changed in flight by the PAW