### PR TITLE
SAS upgrades

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Subsatellite_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Subsatellite_Core.cfg
@@ -102,6 +102,28 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Diamant_Asterix.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Diamant_Asterix.cfg
@@ -129,6 +129,18 @@ MODEL
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 }

--- a/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Diamant_Diapason.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Diamant_Diapason.cfg
@@ -79,6 +79,18 @@ MODEL
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 	

--- a/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Explorer1.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Explorer1.cfg
@@ -58,6 +58,22 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+		}
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Pioneer1.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Pioneer1.cfg
@@ -76,6 +76,28 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Pioneer4.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Pioneer4.cfg
@@ -72,12 +72,6 @@ MODEL
 				description__ = SAS Upgrade
 				SASServiceLevel = 2
 			}
-			UPGRADE
-			{
-				name__ = bluedog_SAS3
-				description__ = SAS Upgrade
-				SASServiceLevel = 3
-			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Pioneer4.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Explorer/bluedog_Pioneer4.cfg
@@ -57,6 +57,28 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/AIMP/bluedog_AIMP_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/AIMP/bluedog_AIMP_Core.cfg
@@ -79,6 +79,28 @@ PART
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Alouette/bluedog_Alouette_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Alouette/bluedog_Alouette_Core.cfg
@@ -90,6 +90,27 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Helios/bluedog_Helios_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Helios/bluedog_Helios_Core.cfg
@@ -71,6 +71,28 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/IDCSP/bluedog_IDCSP_Probe.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/IDCSP/bluedog_IDCSP_Probe.cfg
@@ -136,6 +136,27 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_11.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_11.cfg
@@ -89,6 +89,27 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_7.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_7.cfg
@@ -101,6 +101,27 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_8.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_8.cfg
@@ -101,6 +101,27 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_S45.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_S45.cfg
@@ -100,6 +100,27 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_S46.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Explorer_S46.cfg
@@ -88,6 +88,27 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Pioneer_1.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Pioneer_1.cfg
@@ -78,6 +78,22 @@ PART
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+		}
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Pioneer_4.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/JunoProbes/bluedog_Pioneer_4.cfg
@@ -61,6 +61,22 @@ PART
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+		}
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/LunarOrbiter/bluedog_LunarOrbiter_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/LunarOrbiter/bluedog_LunarOrbiter_Core.cfg
@@ -123,6 +123,18 @@ PART
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Nimbus/bluedog_Nimbus_EarlyControlCore.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Nimbus/bluedog_Nimbus_EarlyControlCore.cfg
@@ -75,6 +75,18 @@ PART
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Nimbus/bluedog_Nimbus_LateControlCore.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Nimbus/bluedog_Nimbus_LateControlCore.cfg
@@ -148,6 +148,18 @@ PART
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/OSO/bluedog_OSO_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/OSO/bluedog_OSO_Core.cfg
@@ -80,6 +80,28 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_MarinerB_Bus.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_MarinerB_Bus.cfg
@@ -137,6 +137,18 @@ PART
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Ranger_BareCore.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Ranger_BareCore.cfg
@@ -75,6 +75,18 @@ PART
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Ranger_Block2_RoughLander.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Ranger_Block2_RoughLander.cfg
@@ -64,6 +64,16 @@ PART
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+		}
 	}
 
 //	MODULE

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Ranger_Bus.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Ranger_Bus.cfg
@@ -134,6 +134,18 @@ PART
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/TIROS/bluedog_TIROS.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/TIROS/bluedog_TIROS.cfg
@@ -147,6 +147,27 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/TRYP/bluedog_TRYP_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/TRYP/bluedog_TRYP_Core.cfg
@@ -68,6 +68,28 @@ PART
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_OGO_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_OGO_Core.cfg
@@ -79,6 +79,18 @@ MODEL
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_Pioneer6_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_Pioneer6_Core.cfg
@@ -70,6 +70,28 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
+		}
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_Sputnik3_Core.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_Sputnik3_Core.cfg
@@ -97,6 +97,18 @@ MODEL
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_veneraProbe.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/bluedog_veneraProbe.cfg
@@ -78,6 +78,18 @@ MODEL
 				description__ = SAS Upgrade
 				SASServiceLevel = 1
 			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS3
+				description__ = SAS Upgrade
+				SASServiceLevel = 3
+			}
 		}
 	}
 

--- a/Gamedata/Bluedog_DB/Parts/Redstone/bluedog_Juno1_Explorer1.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Redstone/bluedog_Juno1_Explorer1.cfg
@@ -56,6 +56,22 @@ PART
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+		}
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Vanguard/bluedog_Vanguard_Satellite1.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Vanguard/bluedog_Vanguard_Satellite1.cfg
@@ -59,6 +59,22 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+		}
 	}
 
 //	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Vanguard/bluedog_Vanguard_Satellite2.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Vanguard/bluedog_Vanguard_Satellite2.cfg
@@ -59,6 +59,22 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+		}
 	}
 
 //	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Vanguard/bluedog_Vanguard_Satellite3.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Vanguard/bluedog_Vanguard_Satellite3.cfg
@@ -59,6 +59,22 @@ MODEL
 	MODULE
 	{
 		name = ModuleSAS
+		SASServiceLevel = 0
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = bluedog_SAS1
+				description__ = SAS Upgrade
+				SASServiceLevel = 1
+			}
+			UPGRADE
+			{
+				name__ = bluedog_SAS2
+				description__ = SAS Upgrade
+				SASServiceLevel = 2
+			}
+		}
 	}
 
 //	MODULE


### PR DESCRIPTION
SAS upgrades to level 3 for most probes, level 2 for pioneer 1/4, explorer 1, and vanguards