### PR TITLE
fix for staging disabling

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p3125m_HighProfile.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p3125m_HighProfile.cfg
@@ -61,6 +61,7 @@ PART
 		isOmniDecoupler = false
 		ejectionForce = 3
 		explosiveNodeID = top
+		stagingEnabled = False
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p3125m_LowProfile.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p3125m_LowProfile.cfg
@@ -61,6 +61,7 @@ PART
 		isOmniDecoupler = false
 		ejectionForce = 3
 		explosiveNodeID = top
+		stagingEnabled = False
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p3125m_MediumProfile.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p3125m_MediumProfile.cfg
@@ -61,6 +61,7 @@ PART
 		isOmniDecoupler = false
 		ejectionForce = 3
 		explosiveNodeID = top
+		stagingEnabled = False
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p625m_HighProfile.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p625m_HighProfile.cfg
@@ -61,6 +61,7 @@ PART
 		isOmniDecoupler = false
 		ejectionForce = 8
 		explosiveNodeID = top
+		stagingEnabled = False
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p625m_LowProfile.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p625m_LowProfile.cfg
@@ -61,6 +61,7 @@ PART
 		isOmniDecoupler = false
 		ejectionForce = 8
 		explosiveNodeID = top
+		stagingEnabled = False
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p625m_MediumProfile.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Generic/PayloadSeparators/bluedog_PSM_0p625m_MediumProfile.cfg
@@ -61,6 +61,7 @@ PART
 		isOmniDecoupler = false
 		ejectionForce = 8
 		explosiveNodeID = top
+		stagingEnabled = False
 	}
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Titan/bluedog_SRMU_Full.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Titan/bluedog_SRMU_Full.cfg
@@ -312,6 +312,7 @@ PART
 		{
 			name = Inline
 			transform = Inline
+			CoMOffset = 0.0, 3.0, 0
 		}
 
 		SUBTYPE

--- a/Gamedata/Bluedog_DB/Parts/Titan/bluedog_SRMU_TwoSeg.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Titan/bluedog_SRMU_TwoSeg.cfg
@@ -311,6 +311,7 @@ PART
 		{
 			name = Inline
 			transform = Inline
+			CoMOffset = 0.0, 3.0, 0
 		}
 
 		SUBTYPE

--- a/Gamedata/Bluedog_DB/Parts/Titan/bluedog_SRMU_XL.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Titan/bluedog_SRMU_XL.cfg
@@ -313,6 +313,7 @@ PART
 		{
 			name = Inline
 			transform = Inline
+			CoMOffset = 0.0, 3.0, 0
 		}
 
 		SUBTYPE


### PR DESCRIPTION
The option to disable staging wasn't working on the small payload separators, as the stock decoupler module didn't have it's staging disabled.