### PR TITLE
BDB Contracts add-on

### DIFF
--- a/Gamedata/Bluedog_DB/Contracts/BDB_AIMP.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_AIMP.cfg
@@ -1,0 +1,205 @@
+// Contract for BDB AIMP satellites 
+//   Author: Morphisor
+
+CONTRACT_TYPE
+{
+    name = BDB_AIMP
+    group = BluedogDB
+    genericTitle = Perform a magnetic field study.
+    genericDescription = Perform a magnetic field study from varying orbits.
+	
+	title = Perform a magnetic field study of @targetBody.
+	description = Our previous studies into the geophysical properties of @targetBody have shown us the presence of an ominously named phenomenon called the magnetosphere. Wernher initially jumped around the lab with joy, screaming that he'd been right all along and there really is a Dyson sphere after all. He quickly became disappointed however, when we told him it was just a giant magnetic field.&br;&br; After overcoming his disappointment and having stuffed himself with comfort food (we hear his favorite is peanut-butter-jelly donuts with a guacamole side), Wernher concluded the magnetosphere is still very much worth studying. He came up with the following mission to maximize our understanding of this magnet stuff. Go do science!
+	
+    synopsis = <color=yellow>Launch a AIMP research satellite into the specified orbits around @targetBody and perform the requested experiments.</color>
+	notes = In assembly, use the tag 'AIMP' or 'IMP' to find components fitting for this mission.
+    completedMessage = Wernher is still disappointed, but at least we are now sure that @targetBody is a giant, magnet that may or may not be edible.
+
+    // 1 at a time
+    maxSimultaneous = 1
+
+    // Always offered by Bluedog Design Bureau
+    agent = Bluedog Design Bureau
+
+    targetBody = @targetBody1
+
+    // Contract rewards
+    rewardFunds = Random(@BluedogDB:Kerbucks105,@BluedogDB:Kerbucks2)
+    rewardReputation = Random(4.0, 6.0)
+
+	// Randomly select a possible target body.
+    DATA
+    {
+        type = CelestialBody
+		hidden = true
+		
+        targetBody1 = @validBodies.Random()
+    }
+	
+	// Target any body that has been reached, except homeworld.
+	DATA
+    {
+        type = List<CelestialBody>
+        hidden = true
+
+        validBodies = ReachedBodies().Where(cb => cb != HomeWorld())
+    }
+	
+    // Hardcoded list of specific experiments
+    DATA
+    {
+        type = List<ScienceExperiment>
+        hidden = true
+
+        experiments = [bd_magScan]
+    }
+	
+	// Mission to do magScans for both SpaceLow and SpaceHigh. 
+    DATA
+    {
+        type = List<ScienceSubject>
+        hidden = true
+
+        scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
+		scienceSubjectsTemp2 = @scienceSubjectsTemp1.Where(s => !s.Biome().IsKSC())
+		scienceSubjectsTemp3 = @scienceSubjectsTemp2.Where(s => s.Situation() == InSpaceLow || s.Situation() == InSpaceHigh)
+        scienceSubjects = @scienceSubjectsTemp3
+    }
+	
+	// Science recovery: transmit, recover, or ideal.
+    DATA
+    {
+        type = ScienceRecoveryMethod
+        hidden = true
+
+        recoveryMethod = Transmit
+    }
+
+	PARAMETER
+    {
+        name = AIMP Satellite
+        type = VesselParameterGroup
+        title = Launch a new AIMP research satellite
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = The satellite must be a new vessel
+		}
+		
+		PARAMETER
+		{
+			name = Sequence
+			type = Sequence
+			
+			//Orbit with random components to be both somewhat unpredictable and scalable to any size body. PeA needs to be below High Space to ensure both space situations are guaranteed to be within the parameters.
+			PARAMETER
+			{
+				name = Orbit
+				type = Orbit
+				title = Put AIMP into a somewhat elliptical orbit
+			
+				minApA = Random(1,1.1) * @targetBody.SpaceAltitudeThreshold()
+				maxApA = Random(1.1,1.2) * @targetBody.SpaceAltitudeThreshold()
+				maxPeA = (Random(0.3,0.6) * @targetBody.SpaceAltitudeThreshold()) < @targetBody.AtmosphereAltitude() ? (1.1 * @targetBody.AtmosphereAltitude()) :  (Random(0.3,0.6) * @targetBody.SpaceAltitudeThreshold())
+				minInclination = Random(10,25)
+				maxInclination = Random(30,40)
+			}
+			
+			PARAMETER
+			{
+				name = CollectScience
+				type = CollectScience
+				title = Perform the experiment from both the lower and the higher altitudes within this orbit
+
+				biome = @scienceSubject.Biome()
+				situation = @scienceSubject.Situation()
+				experiment = @scienceSubject.Experiment()
+				recoveryMethod = @/recoveryMethod
+
+				rewardFunds = Random(1000.0, 2000.0)
+
+				ITERATOR
+				{
+					type = ScienceSubject
+					scienceSubject = @/scienceSubjects
+				}
+			}
+			
+			//Orbit with random components to be both somewhat unpredictable and scalable to any size body. PeA needs to be below High Space to ensure both space situations are guaranteed to be within the parameters.
+			PARAMETER
+			{
+				name = Orbit
+				type = Orbit
+				title = Now change the orbit into a higher, more elliptical orbit
+			
+				minApA = Random(7,8) * @targetBody.Radius()
+				maxApA = Random(8.1,9) * @targetBody.Radius()
+				minPeA = (Random(0.3,0.6) * @targetBody.SpaceAltitudeThreshold()) < @targetBody.AtmosphereAltitude() ? (1.1 * @targetBody.AtmosphereAltitude()) :  (Random(0.3,0.6) * @targetBody.SpaceAltitudeThreshold())
+				maxPeA = (Random(0.75,0.95) * @targetBody.SpaceAltitudeThreshold()) < @targetBody.AtmosphereAltitude() ? (1.1 * @targetBody.AtmosphereAltitude()) :  (Random(0.75,0.95) * @targetBody.SpaceAltitudeThreshold())
+				minInclination = Random(10,25)
+				maxInclination = Random(30,40)
+			}
+			
+			PARAMETER
+			{
+				name = CollectScience
+				type = CollectScience
+				title = Again perform the experiment from both the lower and the higher altitudes within this orbit
+
+				biome = @scienceSubject.Biome()
+				situation = @scienceSubject.Situation()
+				experiment = @scienceSubject.Experiment()
+				recoveryMethod = @/recoveryMethod
+
+				rewardFunds = Random(1000.0, 2000.0)
+
+				ITERATOR
+				{
+					type = ScienceSubject
+					scienceSubject = @/scienceSubjects
+				}
+			}
+			
+		}
+    }
+
+
+	
+	// Contract only becomes available after homeworld has been orbited.
+    REQUIREMENT
+    {
+        type = Orbit 
+        targetBody = HomeWorld()
+    }
+	
+	// Mission is no longer offered for bodies that have been landed on and returned from. This is to stop endless repetitions offered for bodies that have been largely explored already.
+	REQUIREMENT
+	{
+    name = ReturnFromSurface
+    type = ReturnFromSurface
+	invertRequirement = true
+	
+    targetBody = @targetBody
+	}
+	
+	//Must have completed OGO contract first.
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = BDB_GeoStudy
+		minCount = 1
+		cooldownDuration = 0d
+	}
+	
+	// This requirement specifies the nodes that the parts with the required experiments currently reside in. Deliberately not specifying particular parts, so any part with the experiment can be used. If all applicable parts get placed to later nodes, could lead to issues however.
+
+    REQUIREMENT
+    {
+        type = TechResearched
+
+        tech = survivability
+    }
+}

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Corona.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Corona.cfg
@@ -1,0 +1,164 @@
+// Contract for BDB KH-1/4 Corona satellites 
+//   Author: Morphisor
+
+CONTRACT_TYPE
+{
+    name = BDB_Corona
+    group = BluedogDB
+    genericTitle = Perform photo reconnaissance.
+    genericDescription = Perform photo reconnaissance of the specified areas.
+	
+	title = Perform photo reconnaissance from a polar orbit of @targetBody.
+	description = Welcome back, Kommander. We have just intercepted an encrypted transmission suggesting that our rivals, those Kommy Krussians, may have set up suspicious new activities in several areas on @targetBody. Our Kovert Ops units are out of reach, so we want you to get up there and take pictures of the suspected areas. If there's any Krussian activity there, we will know. Oh and you will have to return the film canister back to base, we haven't figured out how to turn black and white into 1's and 0's yet.
+	
+    synopsis = <color=yellow>Launch a Corona recon satellite into space around @targetBody and perform photo recon of the specified areas.</color>
+	notes = In assembly, use the tag 'Corona' to find components fitting for this mission.
+    completedMessage = Either those Krussians have developed excellent camouflage, or we really are just looking at a Kerbal-shaped rock formation. We'll get them next time!
+
+    // 1 at a time
+    maxSimultaneous = 1
+
+    // Always offered by Bluedog Design Bureau
+    agent = Bluedog Design Bureau
+
+    targetBody = @targetBody1
+
+    // Contract rewards
+    rewardFunds = Random(@BluedogDB:Kerbucks105,@BluedogDB:Kerbucks2)
+    rewardReputation = Random(4.0, 8.0)
+
+	// Randomly select a possible target body.
+    DATA
+    {
+        type = CelestialBody
+		hidden = true
+		
+        targetBody1 = @validBodies.Random()
+    }
+	
+	// Any body that has been reached can be targeted.
+	DATA
+    {
+        type = List<CelestialBody>
+        hidden = true
+
+        validBodies = ReachedBodies()
+    }
+	
+    // Hardcoded list of specific experiments
+    DATA
+    {
+        type = List<ScienceExperiment>
+        hidden = true
+
+        experiments = [bd_mapping]
+    }
+	
+	// Randomly select 2 valid biomes to study from low space.
+    DATA
+    {
+        type = List<ScienceSubject>
+        hidden = true
+
+        scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
+		scienceSubjectsTemp2 = @scienceSubjectsTemp1.Where(s => !s.Biome().IsKSC())
+		scienceSubjectsTemp3 = @scienceSubjectsTemp2.Where(s => s.Situation() == InSpaceLow)
+        scienceSubjects = @scienceSubjectsTemp3.Random(2)
+    }
+	
+	// Science recovery: transmit, recover, or ideal.
+    DATA
+    {
+        type = ScienceRecoveryMethod
+
+        hidden = true
+
+        recoveryMethod = Recover
+    }
+	
+	PARAMETER
+    {
+        name = Corona Recon Satellite
+        type = VesselParameterGroup
+        title = Launch a new Corona recon satellite
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = The satellite must be a new vessel
+		}
+		
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+		}
+		
+		PARAMETER
+		{
+			name = PartValidation
+			type = PartValidation
+			part = bluedog_Keyhole_Camera_KH1
+			part = bluedog_Keyhole_Camera_KH4
+			part = bluedog_Keyhole_Camera_KH4B
+			
+			title = You should take a proper camera with you
+		}
+		
+		//Orbit with random components to be both somewhat unpredictable and scalable to any size body. PeA needs to be below High Space to ensure both space situations are guaranteed to be within the parameters.
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			title = Achieve the specified polar low space orbit
+			
+			maxApA = Random(0.4,0.5) * @targetBody.SpaceAltitudeThreshold()
+			maxPeA = (Random(0.3,0.4) * @targetBody.SpaceAltitudeThreshold()) < @targetBody.AtmosphereAltitude() ? @targetBody.AtmosphereAltitude() :  (Random(0.3,0.4) * @targetBody.SpaceAltitudeThreshold())
+			maxEccentricity = 0.1
+			minInclination = Random(70,85)
+			maxInclination = Random(90,105)
+		}
+    }
+
+	PARAMETER
+	{
+		name = CollectScience
+		type = CollectScience
+
+		title = Take a photo of the specified area
+		biome = @scienceSubject.Biome()
+		situation = @scienceSubject.Situation()
+		experiment = @scienceSubject.Experiment()
+		recoveryMethod = @/recoveryMethod
+
+		ITERATOR
+		{
+			type = ScienceSubject
+			scienceSubject = @/scienceSubjects
+		}
+	}
+	
+	PARAMETER
+	{
+		name = ReturnHome
+		type = ReturnHome
+		title = Recover the film canister
+	}
+	
+	// Contract only becomes available after homeworld has been orbited.
+    REQUIREMENT
+    {
+        type = Orbit
+        targetBody = HomeWorld()
+    }
+	
+	// This requirement specifies the nodes that the parts with the required experiments currently reside in. Deliberately not specifying particular parts, so any part with the experiment can be used. If all applicable parts get placed to later nodes, could lead to issues however.
+	REQUIREMENT
+    {
+        type = TechResearched
+		tech = engineering101
+    }
+}

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Gambit.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Gambit.cfg
@@ -1,0 +1,172 @@
+// Contract for BDB KH-7/8 Gambit satellites 
+//   Author: Morphisor
+
+CONTRACT_TYPE
+{
+    name = BDB_Gambit
+    group = BluedogDB
+    genericTitle = Perform photo surveillance.
+    genericDescription = Perform photo surveillance of the specified areas.
+	
+	title = Perform photo surveillance from a polar orbit of @targetBody.
+	description = Welcome back, Kommander. Despite our previous reconnaissance finding mostly strange rock formations, we believe the Krussians are once again at it on @targetBody. We want you to take a more modern "Gambit" surveillance satellite into orbit of @targetBody, scan the specified areas with a more advanced camera system and return the film back to base. This message is top secret and will self-destruct in 3...2..1.... Wait, did Jeb get away with the explosives again?
+	
+    synopsis = <color=yellow>Launch a Gambit surveillance satellite into space around @targetBody and perform photo surveillance of the specified areas.</color>
+	notes = In assembly, use the tag 'Gambit' to find components fitting for this mission.
+    completedMessage = Still no sign of those Krussians! You're beginning to suspect High Kommand simply wanted new wallpapers.
+
+    // 1 at a time
+    maxSimultaneous = 1
+
+    // Always offered by Bluedog Design Bureau
+    agent = Bluedog Design Bureau
+
+    targetBody = @targetBody1
+
+    // Contract rewards
+    rewardFunds = Random(@BluedogDB:Kerbucks2,@BluedogDB:Kerbucks3)
+    rewardReputation = Random(4.0, 8.0)
+
+	// Randomly select a possible target body.
+    DATA
+    {
+        type = CelestialBody
+		hidden = true
+		
+        targetBody1 = @validBodies.Random()
+    }
+	
+	// Any body that has been reached can be targeted.
+	DATA
+    {
+        type = List<CelestialBody>
+        hidden = true
+
+        validBodies = ReachedBodies()
+    }
+	
+    // Hardcoded list of specific experiments
+    DATA
+    {
+        type = List<ScienceExperiment>
+        hidden = true
+
+        experiments = [bd_surveillance]
+    }
+	
+	// Randomly select 4 valid biomes to study from low space.
+    DATA
+    {
+        type = List<ScienceSubject>
+        hidden = true
+
+        scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
+		scienceSubjectsTemp2 = @scienceSubjectsTemp1.Where(s => !s.Biome().IsKSC())
+		scienceSubjectsTemp3 = @scienceSubjectsTemp2.Where(s => s.Situation() == InSpaceLow)
+        scienceSubjects = @scienceSubjectsTemp3.Random(4)
+    }
+	
+	// Science recovery: transmit, recover, or ideal.
+    DATA
+    {
+        type = ScienceRecoveryMethod
+
+        hidden = true
+
+        recoveryMethod = Recover
+    }
+	
+	PARAMETER
+    {
+        name = Gambit Surveillance Satellite
+        type = VesselParameterGroup
+        title = Launch a new Gambit surveillance satellite
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = The satellite must be a new vessel
+		}
+		
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+		}
+		
+		PARAMETER
+		{
+			name = PartValidation
+			type = PartValidation
+			part = bluedog_Keyhole_Camera_KH7
+			part = bluedog_Keyhole_Camera_KH8
+			
+			title = You should take a proper camera with you
+		}
+		
+		//Orbit with random components to be both somewhat unpredictable and scalable to any size body. PeA needs to be below High Space to ensure both space situations are guaranteed to be within the parameters.
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			title = Achieve the specified polar low space orbit
+			
+			maxApA = Random(0.4,0.5) * @targetBody.SpaceAltitudeThreshold()
+			maxPeA = (Random(0.3,0.4) * @targetBody.SpaceAltitudeThreshold()) < @targetBody.AtmosphereAltitude() ? (1.1 * @targetBody.AtmosphereAltitude()) : (Random(0.3,0.4) * @targetBody.SpaceAltitudeThreshold())
+			maxEccentricity = 0.1
+			minInclination = Random(70,85)
+			maxInclination = Random(90,105)
+		}
+    }
+
+	PARAMETER
+	{
+		name = CollectScience
+		type = CollectScience
+
+		title = Take photos of the specified areas
+		biome = @scienceSubject.Biome()
+		situation = @scienceSubject.Situation()
+		experiment = @scienceSubject.Experiment()
+		recoveryMethod = @/recoveryMethod
+
+		ITERATOR
+		{
+			type = ScienceSubject
+			scienceSubject = @/scienceSubjects
+		}
+	}
+	
+	PARAMETER
+	{
+		name = ReturnHome
+		type = ReturnHome
+		title = Recover the film canister
+	}
+	
+	// Contract only becomes available after homeworld has been orbited.
+    REQUIREMENT
+    {
+        type = Orbit
+        targetBody = HomeWorld()
+    }
+	
+	// This requirement specifies the nodes that the parts with the required experiments currently reside in. Deliberately not specifying particular parts, so any part with the experiment can be used. If all applicable parts get placed to later nodes, could lead to issues however.
+	REQUIREMENT
+    {
+        type = TechResearched
+		tech = basicScience
+    }
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = BDB_Corona
+		minCount = 3
+		cooldownDuration = 0d
+	}
+}

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Nimbus.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Nimbus.cfg
@@ -1,0 +1,164 @@
+// Contract for BDB Nimbus satellites 
+//   Author: Morphisor
+
+CONTRACT_TYPE
+{
+    name = BDB_Nimbus
+    group = BluedogDB
+    genericTitle = Perform a weather study.
+    genericDescription = Perform a weather study from orbit of a planet.
+	
+	title = Perform a weather study from orbit of @targetBody.
+	description = You've heard of weather, right? It's that stuff that makes moisture appear out of thin air. Now, one of our slightly more eccentric colleagues was looking up at the sky recently and he's saying there some bad weather about that may interfere with our plans. So, we decided that you should do what we do best: launch a rocket up and around to go check it out. Your mission is to determine the weather out at the indicated areas and whether or not we can weather it.
+	
+    synopsis = <color=yellow>Launch a Nimbus weather satellite into space around @targetBody and perform the requested experiments.</color>
+	notes = In assembly, use the tag 'Nimbus' to find components fitting for this mission.
+    completedMessage = Thanks to the extensive weather data you gathered, we can now predict with absolute certainty that the weather is going to be completely unpredictable.
+
+    // 1 at a time
+    maxSimultaneous = 1
+
+    // Always offered by Bluedog Design Bureau
+    agent = Bluedog Design Bureau
+
+    targetBody = @targetBody1
+
+    // Contract rewards
+    rewardFunds = Random(@BluedogDB:Kerbucks1,@BluedogDB:Kerbucks105)
+    rewardReputation = Random(2.0, 5.0)
+
+	// Randomly select a possible target body.
+    DATA
+    {
+        type = CelestialBody
+		hidden = true
+		
+        targetBody1 = @validBodies.Random()
+    }
+	
+	// Only bodies with Atmosphere can be targeted.
+	DATA
+    {
+        type = List<CelestialBody>
+        hidden = true
+
+        validBodies = ReachedBodies().Where(cb => cb.HasAtmosphere())
+    }
+	
+    // Hardcoded list of specific experiments
+    DATA
+    {
+        type = List<ScienceExperiment>
+        hidden = true
+
+        experiments = [bd_weather , bd_microwaveSpec , bd_IRspec , bd_IRradiometer]
+    }
+	
+	// Mission activates only for science that has not yet been done and triggers only when at least 3 and up to 6 different experiment/location combinations are available.
+    DATA
+    {
+        type = List<ScienceSubject>
+        hidden = true
+
+        scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
+        scienceSubjectsTemp2 = @scienceSubjectsTemp1.Where(s => s.CollectedScience() == 0.0)
+		scienceSubjectsTemp3 = @scienceSubjectsTemp2.Where(s => !s.Biome().IsKSC())
+		scienceSubjectsTemp4 = @scienceSubjectsTemp3.Where(s => s.Situation() == InSpaceLow || s.Situation() == InSpaceHigh)
+        scienceSubjects = @scienceSubjectsTemp4.Random(3,6)
+    }
+	
+	// Science recovery: transmit, recover, or ideal.
+    DATA
+    {
+        type = ScienceRecoveryMethod
+
+        hidden = true
+
+        recoveryMethod = Transmit
+    }
+
+	PARAMETER
+    {
+        name = Nimbus Satellite
+        type = VesselParameterGroup
+        title = Launch a new Nimbus weather satellite
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = The satellite must be a new vessel
+		}
+		
+		//Orbit with random components to be both somewhat unpredictable and scalable to any size body. PeA needs to be below High Space to ensure both space situations are guaranteed to be within the parameters.
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			title = Achieve a near-circular, polar orbit
+				
+			minApA = Random(1,1.1) * @targetBody.SpaceAltitudeThreshold()
+			maxApA = Random(1.1,1.2) * @targetBody.SpaceAltitudeThreshold()
+			maxPeA = @targetBody.SpaceAltitudeThreshold()
+			maxEccentricity = 0.1
+			minInclination = Random(75,85)
+			maxInclination = Random(95,105)
+				
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+				duration = 45s
+
+				preWaitText = Confirming orbit
+				waitingText = Confirming orbit
+				completionText = Orbit confirmed
+			}
+		}
+    }
+
+	PARAMETER
+	{
+		type = CollectScience
+
+		biome = @scienceSubject.Biome()
+		situation = @scienceSubject.Situation()
+		experiment = @scienceSubject.Experiment()
+		recoveryMethod = @/recoveryMethod
+
+		rewardFunds = Random(3000.0, 5000.0)
+
+		ITERATOR
+		{
+			type = ScienceSubject
+			scienceSubject = @/scienceSubjects
+		}
+	}
+	
+	// Contract only becomes available after homeworld has been orbited.
+    REQUIREMENT
+    {
+        type = Orbit 
+        targetBody = HomeWorld()
+    }
+	
+	// This requirement specifies the nodes that the parts with the required experiments currently reside in. Deliberately not specifying particular parts, so any part with the experiment can be used. If all applicable parts get placed to later nodes, could lead to issues however.
+	REQUIREMENT
+    {
+        type = Any
+
+        REQUIREMENT
+        {
+            type = TechResearched
+
+            tech = basicScience
+        }
+
+        REQUIREMENT
+        {
+            type = TechResearched
+
+            tech = miniaturization
+        }
+    }
+}

--- a/Gamedata/Bluedog_DB/Contracts/BDB_OGO.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_OGO.cfg
@@ -1,0 +1,169 @@
+// Contract for BDB Orbiting Geophysical Observatory (OSO) satellites 
+//   Author: Morphisor
+
+CONTRACT_TYPE
+{
+    name = BDB_GeoStudy
+    group = BluedogDB
+    genericTitle = Perform a Geophysical study
+    genericDescription = Perform a Geophysical study from orbit of a planet or moon.
+	
+	title = Perform a Geophysical study from orbit of @targetBody.
+	description = Previous studies of @targetBody have shown all kinds of strange things happening on and above the surface. Being an enterprising space program, naturally we proposed to send over one of our test dum...ahem pilots right away. Sadly the board declined our proposal, on the grounds that it's unethical to land Kerbals without a return plan. Bah, bureaucrats. Instead, you are hereby tasked with sending an unmanned probe into a polar orbit of @targetBody to conduct a set of experiments and transmit their results back to us. If we can make up the results with just the right phrasing, we just might get to do a manned mission after all - you ARE with us on this, right?
+	
+    synopsis = <color=yellow>Launch an Orbiting Geophysical Observatory (OGO) into space around @targetBody and perform the requested experiments.</color>
+	notes = In assembly, use the tag 'OGO' to find components fitting for this mission.
+    completedMessage = Excellent! All these results show nothing anomalous, or even anything we didn't yet know at all! Start prepping those interns, we got flights to plan.
+
+    // 1 at a time
+    maxSimultaneous = 1
+
+    // Always offered by Bluedog Design Bureau
+    agent = Bluedog Design Bureau
+
+    targetBody = @targetBody1
+
+    // Contract rewards
+    rewardFunds = Random(@BluedogDB:Kerbucks1,@BluedogDB:Kerbucks105)
+    rewardReputation = Random(2.0, 5.0)
+
+	// Randomly select a possible target body.
+    DATA
+    {
+        type = CelestialBody
+		hidden = true
+		
+        targetBody1 = @validBodies.Random()
+    }
+	
+	// Any body that has been reached can be targeted.
+	DATA
+    {
+        type = List<CelestialBody>
+        hidden = true
+
+        validBodies = ReachedBodies()
+    }
+	
+    // Hardcoded list of specific experiments
+    DATA
+    {
+        type = List<ScienceExperiment>
+        hidden = true
+
+        experiments = [bd_ionElec , gravityScan , logIonTrap , bd_gammaRay, bd_magScan , bd_massSpec]
+    }
+	
+	// Mission activates only for science that has not yet been done and triggers only when at least 4 and up to 6 different experiment/location combinations are available.
+    DATA
+    {
+        type = List<ScienceSubject>
+        hidden = true
+
+        scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
+        scienceSubjectsTemp2 = @scienceSubjectsTemp1.Where(s => s.CollectedScience() == 0.0)
+		scienceSubjectsTemp3 = @scienceSubjectsTemp2.Where(s => !s.Biome().IsKSC())
+		scienceSubjectsTemp4 = @scienceSubjectsTemp3.Where(s => s.Situation() == InSpaceLow || s.Situation() == InSpaceHigh)
+        scienceSubjects = @scienceSubjectsTemp4.Random(4,6)
+    }
+	
+	// Science recovery: transmit, recover, or ideal.
+    DATA
+    {
+        type = ScienceRecoveryMethod
+
+        hidden = true
+
+        recoveryMethod = Transmit
+    }
+
+	PARAMETER
+    {
+        name = OGO Satellite
+        type = VesselParameterGroup
+        title = Launch a new OGO geophysical satellite
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = The satellite must be a new vessel
+		}
+		
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+		}
+		
+		PARAMETER
+		{
+			name = PartValidation
+			type = PartValidation
+			partModule = ModuleDeployableSolarPanel
+			title = Have at least 1 solar panel on this spacecraft
+		}
+		
+		//Orbit with random components to be both somewhat unpredictable and scalable to any size body. PeA needs to be below High Space to ensure both space situations are guaranteed to be within the parameters.
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			title = Achieve the specified orbit and hold for 1 day to gather data
+				
+			minApA = Random(10,11.45) * @targetBody.Radius()
+			maxApA = Random(11.5,12) * @targetBody.Radius()
+			maxPeA = @targetBody.SpaceAltitudeThreshold()
+			minEccentricity = Random(0.7,0.8)
+			minInclination = Random(70,85)
+			maxInclination = Random(90,100)
+		}
+    }
+	
+	PARAMETER
+	{
+		name = Duration
+		type = Duration
+		duration = 1d
+
+		preWaitText = Holding to gather data
+		waitingText = Holding to gather data
+		completionText = Data complete
+		startCriteria = PARAMETER_COMPLETION
+		parameter = Orbit
+	}
+
+	PARAMETER
+	{
+		type = CollectScience
+
+		biome = @scienceSubject.Biome()
+		situation = @scienceSubject.Situation()
+		experiment = @scienceSubject.Experiment()
+		recoveryMethod = @/recoveryMethod
+
+		rewardFunds = Random(3000.0, 5000.0)
+
+		ITERATOR
+		{
+			type = ScienceSubject
+			scienceSubject = @/scienceSubjects
+		}
+	}
+	
+	// Contract only becomes available after homeworld has been orbited.
+    REQUIREMENT
+    {
+        type = Orbit
+        targetBody = HomeWorld()
+    }
+	
+	// This requirement specifies the nodes that the parts with the required experiments currently reside in. Deliberately not specifying particular parts, so any part with the experiment can be used. If all applicable parts get placed to later nodes, could lead to issues however.
+	REQUIREMENT
+    {
+        type = TechResearched
+		tech = basicScience
+    }
+}

--- a/Gamedata/Bluedog_DB/Contracts/BDB_OSO.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_OSO.cfg
@@ -1,0 +1,165 @@
+// Contract for BDB Orbital Solar Observatory (OSO) satellites 
+//   Author: Morphisor
+
+CONTRACT_TYPE
+{
+    name = BDB_SolarStudy
+    group = BluedogDB
+    genericTitle = Perform a Kerbolar study
+    genericDescription = Perform a Kerbolar study from orbit of a planet or moon.
+	
+	title = Perform a Kerbolar study from orbit of @targetBody.
+	description = Kerbol has been a steady source of beautiful light and warmth for as long as Kerbalkind can remember. Our top scientists have however developed a sneaking suspicion that there's more to it. So we need someone to perform a further study of Kerbol from orbit of @targetBody. That someone is you.&br;&br;While we're pretty sure all this talk of solar radiation and other strange mumblings we overheard the eggheads saying are perfectly harmless, there's no need to expose Kerbals for these experiments. But we won't stop you if you want to do so anyway! Just sign this waiver first.
+	
+    synopsis = <color=yellow>Launch an Orbiting Kerbolar Observatory (OSO) into space around @targetBody and perform the requested experiments.</color>
+	notes = In assembly, use the tag 'OSO' to find components fitting for this mission.
+    completedMessage = The results you obtained were certainly informative. Go on, move along now, nothing to see here.
+
+    // 1 at a time
+    maxSimultaneous = 1
+
+    // Always offered by Bluedog Design Bureau
+    agent = Bluedog Design Bureau
+
+    targetBody = @targetBody1
+
+    // Contract rewards
+    rewardFunds = Random(@BluedogDB:Kerbucks1,@BluedogDB:Kerbucks105)
+    rewardReputation = Random(2.0, 5.0)
+
+	// Randomly select a possible target body.
+    DATA
+    {
+        type = CelestialBody
+		hidden = true
+		
+        targetBody1 = @validBodies.Random()
+    }
+	
+	// Any body that has been orbited can be targeted.
+	DATA
+    {
+        type = List<CelestialBody>
+        hidden = true
+
+        validBodies = OrbitedBodies()
+    }
+	
+    // Hardcoded list of specific experiments
+    DATA
+    {
+        type = List<ScienceExperiment>
+        hidden = true
+
+        experiments = [bd_oso , bd_solarWind , bd_photometer]
+    }
+	
+	// Mission activates only for science that has not yet been done and triggers only when at least 2 and up to 4 different experiment/location combinations are available.
+    DATA
+    {
+        type = List<ScienceSubject>
+        hidden = true
+
+        scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
+        scienceSubjectsTemp2 = @scienceSubjectsTemp1.Where(s => s.CollectedScience() == 0.0)
+		scienceSubjectsTemp3 = @scienceSubjectsTemp2.Where(s => !s.Biome().IsKSC())
+		scienceSubjectsTemp4 = @scienceSubjectsTemp3.Where(s => s.Situation() == InSpaceLow || s.Situation() == InSpaceHigh)
+        scienceSubjects = @scienceSubjectsTemp4.Random(2,4)
+    }
+	
+	// Science recovery: transmit, recover, or ideal.
+    DATA
+    {
+        type = ScienceRecoveryMethod
+
+        hidden = true
+
+        recoveryMethod = Transmit
+    }
+
+	PARAMETER
+    {
+        name = OSO Satellite
+        type = VesselParameterGroup
+        title = Launch a new OSO science satellite
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = The satellite must be a new vessel
+		}
+		
+		//Orbit with random components to be both somewhat unpredictable and scalable to any size body. PeA needs to be below High Space to ensure both space situations are guaranteed to be within the parameters.
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			title = Achieve the specified orbit and hold for 1 day to gather data
+				
+			minApA = Random(0.5,1.5) * @targetBody.Radius()
+			maxApA = Random(1.5,2) * @targetBody.Radius()
+			maxPeA = @targetBody.SpaceAltitudeThreshold()
+			minEccentricity = Random(0.05,0.2)
+			minInclination = Random(25,95)
+		}
+    }
+	
+	PARAMETER
+	{
+		name = Duration
+		type = Duration
+		duration = 1d
+
+		preWaitText = Holding to gather data
+		waitingText = Holding to gather data
+		completionText = Data complete
+		startCriteria = PARAMETER_COMPLETION
+		parameter = Orbit
+	}
+
+	PARAMETER
+	{
+		type = CollectScience
+
+		biome = @scienceSubject.Biome()
+		situation = @scienceSubject.Situation()
+		experiment = @scienceSubject.Experiment()
+		recoveryMethod = @/recoveryMethod
+
+		rewardFunds = Random(3000.0, 5000.0)
+
+		ITERATOR
+		{
+			type = ScienceSubject
+			scienceSubject = @/scienceSubjects
+		}
+	}
+	
+	// Contract only becomes available after homeworld has been orbited.
+    REQUIREMENT
+    {
+        type = Orbit
+        targetBody = HomeWorld()
+    }
+	
+	// This requirement specifies the nodes that the parts with the required experiments currently reside in. Deliberately not specifying particular parts, so any part with the experiment can be used. If all applicable parts get placed to later nodes, could lead to issues however.
+	REQUIREMENT
+    {
+        type = Any
+
+        REQUIREMENT
+        {
+            type = TechResearched
+
+            tech = survivability
+        }
+
+        REQUIREMENT
+        {
+            type = TechResearched
+
+            tech = scienceTech
+        }
+    }
+}

--- a/Gamedata/Bluedog_DB/Contracts/BDBcontracts credits & license.txt
+++ b/Gamedata/Bluedog_DB/Contracts/BDBcontracts credits & license.txt
@@ -1,0 +1,16 @@
+BDB contracts designed by: Morphisor
+
+
+DEPENDENCY
+
+Contract Configurator - https://forum.kerbalspaceprogram.com/index.php?/topic/91625-18x-contract-configurator-v1280-2019-10-17/
+
+
+CREDITS
+
+Nightingale - For Contract Configurator and code used from Field Research
+
+
+LICENSE
+
+CC-BY-NC-SA-4.0 - https://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/Gamedata/Bluedog_DB/Contracts/BluedogDBcontracts.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BluedogDBcontracts.cfg
@@ -1,0 +1,57 @@
+// Contract Group definition for all BDB contracts.
+//   Author: Morphisor
+
+CONTRACT_GROUP
+{
+    name = BluedogDB
+    displayName = Bluedog Design Bureau
+
+    minVersion = 1.22.0
+    agent = Bluedog Design Bureau
+
+    tip = They make all the parts no one asks for.
+
+	maxSimultaneous = 6
+	
+    DATA
+    {
+        type = bool
+
+        homeIsMoon = HomeWorld().IsMoon()
+    }
+
+    DATA
+    {
+		type = List<CelestialBody>
+        requiredValue = false
+
+        validBodies = OrbitedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()) && cb != HomeWorld())
+        l2Bodies = @validBodies.Where(cb => cb.Parent() == (@homeIsMoon ? HomeWorld().Parent() : HomeWorld()) || cb == HomeWorld().Parent())
+        l3Bodies = @validBodies.ExcludeAll(@l2Bodies)
+    }
+	
+	DATA
+	{
+		type = double
+		Kerbucks025 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 0.25
+		Kerbucks05 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 0.5
+		Kerbucks075 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 0.75
+		Kerbucks1 = ( HomeWorld().Radius() / 1000 ) * 20
+		Kerbucks105 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 1.5
+		Kerbucks2 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 2
+		Kerbucks3 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 3
+		Kerbucks4 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 4
+		Kerbucks5 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 5
+		Kerbucks6 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 6
+		Kerbucks7 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 7
+		Kerbucks8 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 8
+		Kerbucks9 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 9
+		Kerbucks14 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 14
+		Kerbucks17 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 17
+		Kerbucks21 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 21
+		Kerbucks42 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 42
+		Kerbucks125 = (( HomeWorld().Radius() / 1000 ) * 20 ) * 125
+		title = Money, money, money, money
+		requiredValue = false
+	}
+}


### PR DESCRIPTION
First batch of contracts for BDB science parts. This batch includes 6 different satellite missions modelled after historical profiles. They are however completely scalable, generic and applicable to the entire system.