### PR TITLE
contracts compatibility for DMOS & SCANsat

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/sciencedefs_compatibility.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/sciencedefs_compatibility.cfg
@@ -37,11 +37,44 @@
 	}
 }
 
+//Make contracts using bd_magScan use DMagic magScan
+@CONTRACT_TYPE[BDB_AIMP]:NEEDS[DMagicOrbitalScience]
+{
+	@DATA[experimentslist]
+	{
+		@experiments = [magScan]
+	}
+}
+@CONTRACT_TYPE[BDB_Mariner]:NEEDS[DMagicOrbitalScience]
+{
+	@DATA[experimentslist]
+	{
+		@experiments = [logmmImpacts , logIonTrap, bd_microwaveSpec, bd_Irradiometer, magScan]
+	}
+}
+@CONTRACT_TYPE[BDB_GeoStudy]:NEEDS[DMagicOrbitalScience]
+{
+	@DATA[experimentslist]
+	{
+		@experiments = [bd_ionElec , gravityScan , logIonTrap , bd_gammaRay, magScan , bd_massSpec]
+	}
+}
+
 //Make RPWS use DMagic RPWS
 @PART[bluedog_Helios_RPWSAntenna]:NEEDS[DMagicOrbitalScience]
 {
 	@MODULE[DMModuleScienceAnimateGeneric]{
 		@experimentID = rpwsScan
+	}
+}
+
+
+//Remove bd_radarAltimeter from contract when SCANsat is installed
+@CONTRACT_TYPE[BDB_Ranger]:NEEDS[SCANsat]
+{
+	@DATA[experiments]
+	{
+		@experiments = [bd_camera, bd_ionElec, bd_gammaRay, bd_UVspec, logIonTrap]
 	}
 }
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_AIMP.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_AIMP.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Target any body that has been reached, except homeworld.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = ReachedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()) && cb != HomeWorld())
@@ -49,7 +51,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [bd_magScan]
@@ -58,7 +61,7 @@ CONTRACT_TYPE
 	// Mission to do magScans for both SpaceLow and SpaceHigh. 
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -70,7 +73,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
         hidden = true
 
         recoveryMethod = Transmit

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Corona_KH1.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Corona_KH1.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Any body that has been reached can be targeted.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = ReachedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()))
@@ -49,7 +51,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [bd_mapping]
@@ -58,7 +61,7 @@ CONTRACT_TYPE
 	// Randomly select 1 valid biome to study from low space.
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -70,7 +73,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
 
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Corona_KH4.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Corona_KH4.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Any body that has been reached can be targeted.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = ReachedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()))
@@ -49,7 +51,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [bd_mapping]
@@ -58,7 +61,7 @@ CONTRACT_TYPE
 	// Randomly select 3 valid biomes to study from low space.
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -70,7 +73,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
 
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Gambit.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Gambit.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Any body that has been reached can be targeted.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = ReachedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()))
@@ -49,7 +51,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [bd_surveillance]
@@ -58,7 +61,7 @@ CONTRACT_TYPE
 	// Randomly select 4 valid biomes to study from low space.
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -70,7 +73,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
 
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Gemini.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Gemini.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Any body from which we have returned.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = ReturnedFromBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()))
@@ -177,7 +179,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @/targetVessel1.CelestialBody()
@@ -186,7 +189,8 @@ CONTRACT_TYPE
 	//Find a target ATV.
 	DATA
     {
-        type = Vessel
+        name = targetatv
+		type = Vessel
 		uniquenessCheck = CONTRACT_ACTIVE
 		requiredValue = true
         targetVessel1 = AllVessels().Where(v => v.Parts().Contains(bluedog_GATV_MaterialsBay) == true && v.FreeDockingPorts() == 1).Random()
@@ -196,7 +200,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [logmmImpacts , bd_GeigerCounter ]
@@ -205,7 +210,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
 
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Lunar_Orbiter.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Lunar_Orbiter.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Target any body that has been orbited, except homeworld.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = OrbitedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()) && cb != HomeWorld())
@@ -49,7 +51,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [bd_camera]
@@ -58,7 +61,7 @@ CONTRACT_TYPE
 	// Select situations in both HighSpace and LowSpace to do science from. Separated to allow for sequential mission.
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -72,7 +75,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
         hidden = true
 
         recoveryMethod = Transmit

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Mariner.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Mariner.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies2.Random()
@@ -42,7 +43,8 @@ CONTRACT_TYPE
 	// Target any planet that has been reached as well as the next unreached planet in logical progression.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = ReachedBodies().Where(cb => (cb.IsPlanet() && cb != HomeWorld()))
@@ -55,7 +57,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [logmmImpacts , logIonTrap, bd_microwaveSpec, bd_Irradiometer, bd_magScan]
@@ -64,7 +67,7 @@ CONTRACT_TYPE
 	// Any space science around the target that has not yet been done. Select 5 experiments.
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -77,7 +80,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
         hidden = true
 
         recoveryMethod = Transmit

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Nimbus.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Nimbus.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Only bodies with Atmosphere can be targeted.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = ReachedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()) && cb.HasAtmosphere())
@@ -49,7 +51,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [bd_weather , bd_microwaveSpec , bd_IRspec , bd_IRradiometer]
@@ -58,7 +61,7 @@ CONTRACT_TYPE
 	// Mission activates only for science that has not yet been done and triggers only when at least 3 and up to 6 different experiment/location combinations are available.
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -71,7 +74,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
 
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_OGO.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_OGO.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Any body that has been reached can be targeted.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = ReachedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()))
@@ -49,7 +51,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [bd_ionElec , gravityScan , logIonTrap , bd_gammaRay, bd_magScan , bd_massSpec]
@@ -58,7 +61,7 @@ CONTRACT_TYPE
 	// Mission activates only for science that has not yet been done and triggers only when at least 4 and up to 6 different experiment/location combinations are available.
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -71,7 +74,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
 
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_OSO.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_OSO.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Any body that has been orbited can be targeted.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = OrbitedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()))
@@ -49,7 +51,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [bd_oso , bd_solarWind , bd_photometer]
@@ -58,7 +61,7 @@ CONTRACT_TYPE
 	// Mission activates only for science that has not yet been done and triggers only when at least 2 and up to 4 different experiment/location combinations are available.
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -71,7 +74,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
 
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Ranger.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Ranger.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        type = CelestialBody
+        name = target
+		type = CelestialBody
 		hidden = true
 		
         targetBody1 = @validBodies1.Random()
@@ -40,7 +41,8 @@ CONTRACT_TYPE
 	// Target any body without atmosphere that has been reached.
 	DATA
     {
-        type = List<CelestialBody>
+        name = bodieslist
+		type = List<CelestialBody>
         hidden = true
 
         validBodies = ReachedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()) && cb != HomeWorld())
@@ -50,7 +52,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        type = List<ScienceExperiment>
+        name = experimentslist
+		type = List<ScienceExperiment>
         hidden = true
 
         experiments = [ bd_camera, bd_ionElec, bd_gammaRay, bd_UVspec, bd_radarAltimeter, logIonTrap ]
@@ -59,7 +62,7 @@ CONTRACT_TYPE
 	// Select 4 situations in LowSpace to do science.
     DATA
     {
-        type = List<ScienceSubject>
+		type = List<ScienceSubject>
         hidden = true
 
         scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
@@ -71,7 +74,8 @@ CONTRACT_TYPE
 	//The possible biomes for the target body.
     DATA
     {
-        type = List<Biome>
+        name = biomelist
+		type = List<Biome>
         biomes = @targetBody.Biomes()
         hidden = true
     }
@@ -79,7 +83,7 @@ CONTRACT_TYPE
 	// Science recovery: transmit, recover, or ideal.
     DATA
     {
-        type = ScienceRecoveryMethod
+		type = ScienceRecoveryMethod
         hidden = true
 
         recoveryMethod = Transmit

--- a/Gamedata/Bluedog_DB/Contracts/BluedogDBcontracts.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BluedogDBcontracts.cfg
@@ -15,7 +15,7 @@ CONTRACT_GROUP
 	
     DATA
     {
-        type = bool
+		type = bool
 
         homeIsMoon = HomeWorld().IsMoon()
     }


### PR DESCRIPTION
Use DMOS magScan when installed instead; disallow radarAltimeter when SCANsat installed