### PR TITLE
Gemini & Mariner contract adjustments

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/sciencedefs_compatibility.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/sciencedefs_compatibility.cfg
@@ -49,7 +49,7 @@
 {
 	@DATA[experimentslist]
 	{
-		@experiments = [logmmImpacts , logIonTrap, bd_microwaveSpec, bd_Irradiometer, magScan]
+		@experiments = [logmmImpacts , logIonTrap, bd_microwaveSpec, bd_IRradiometer, magScan]
 	}
 }
 @CONTRACT_TYPE[BDB_GeoStudy]:NEEDS[DMagicOrbitalScience]

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Gemini.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Gemini.cfg
@@ -21,7 +21,7 @@ CONTRACT_TYPE
     // Always offered by Bluedog Design Bureau
     agent = Bluedog Design Bureau
 
-    targetBody = @targetBody4
+    targetBody = @validBodies.Random()
 
     // Contract rewards
 	advanceFunds = Random(@BluedogDB:Kerbucks075,@BluedogDB:Kerbucks1)
@@ -40,14 +40,14 @@ CONTRACT_TYPE
 		targetBody4 = @targetBody3.Random()
     }
 	
-	// Any body from which we have returned.
+	// Any body from which we have orbited.
 	DATA
     {
         name = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
-        validBodies = ReturnedFromBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()))
+        validBodies = OrbitedBodies().Where(cb => (cb.IsPlanet() || cb.IsMoon()))
 		validBodies1 = AllBodies().Where(cb => (cb.IsHomeWorld()))
 		
 		targetBody3 = [@targetBody1, @targetBody2]
@@ -195,9 +195,8 @@ CONTRACT_TYPE
     {
         name = targetatv
 		type = Vessel
-		uniquenessCheck = CONTRACT_ACTIVE
 		requiredValue = true
-        targetVessel1 = AllVessels().Where(v => v.Parts().Contains(bluedog_GATV_MaterialsBay) == true && v.FreeDockingPorts() == 1).Random()
+        targetVessel1 = AllVessels().Where(v => v.Parts().Contains(bluedog_GATV_MaterialsBay) == true).Random()
 		title = Target the Leo ATV
     }
 	

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Mariner.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Mariner.cfg
@@ -21,7 +21,7 @@ CONTRACT_TYPE
     // Always offered by Bluedog Design Bureau
     agent = Bluedog Design Bureau
 
-    targetBody = @targetBody4
+    targetBody = @targetbody3.Random()
 
     // Contract rewards
 	advanceFunds = Random(@BluedogDB:Kerbucks1,@BluedogDB:Kerbucks105)
@@ -35,47 +35,45 @@ CONTRACT_TYPE
 		type = CelestialBody
 		hidden = true
 		
-        targetBody1 = @validBodies2.Random()
-		targetBody2 = @validBodies1.Random()
-		targetBody4 = @targetbody3.Random()
+        targetBody1 = @validBodies.Random()
+		targetBody2 = NextUnreachedBody()
     }		
 	
-	// Target any planet that has been reached as well as the next unreached planet in logical progression.
+	// Target the next unreached body in logical progression.
 	DATA
     {
         name = bodieslist
 		type = List<CelestialBody>
-        hidden = true
-
-        validBodies = ReachedBodies().Where(cb => (cb.IsPlanet() && cb != HomeWorld()))
-		validBodies1 = NextUnreachedBodies(1).Where(cb => cb.IsPlanet())
-		validBodies2 = @validBodies
+		hidden = true
+	
+        validBodies = ReachedBodies().Where(cb => !cb.IsHomeWorld())
 		
 		targetbody3 = [ @targetBody1, @targetBody2 ]
     }
 	
-    // Hardcoded list of specific experiments
+    //Hardcoded list of specific experiments
     DATA
     {
         name = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
-
-        experiments = [logmmImpacts , logIonTrap, bd_microwaveSpec, bd_Irradiometer, bd_magScan]
+	
+        experiments = [logmmImpacts , logIonTrap, bd_microwaveSpec, bd_IRradiometer, bd_magScan]
+		experimentselect = @experiments.Random(3)
     }
 	
 	// Any space science around the target that has not yet been done. Select 5 experiments.
-    DATA
-    {
-		type = List<ScienceSubject>
-        hidden = true
-
-        scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
-		scienceSubjectsTemp2 = @scienceSubjectsTemp1.Where(s => s.CollectedScience() == 0.0)
-		scienceSubjectsTemp3 = @scienceSubjectsTemp2.Where(s => !s.Biome().IsKSC())
-		scienceSubjectsTemp4 = @scienceSubjectsTemp3.Where(s => s.Situation() == InSpaceLow || s.Situation() == InSpaceHigh)
-        scienceSubjects = @scienceSubjectsTemp4.Random(5)
-    }
+    //DATA
+    //{
+	//	type = List<ScienceSubject>
+    //    hidden = true
+	//
+    //    scienceSubjectsTemp1 = AllScienceSubjectsByBodyExperiment([@targetBody], @experiments)
+	//	scienceSubjectsTemp2 = @scienceSubjectsTemp1.Where(s => s.CollectedScience() == 0.0)
+	//	scienceSubjectsTemp3 = @scienceSubjectsTemp2.Where(s => !s.Biome().IsKSC())
+	//	scienceSubjectsTemp4 = @scienceSubjectsTemp3.Where(s => s.Situation() == InSpaceLow || s.Situation() == InSpaceHigh)
+    //    scienceSubjects = @scienceSubjectsTemp4.Random(5)
+    //}
 	
 	// Science recovery: transmit, recover, or ideal.
     DATA
@@ -118,29 +116,22 @@ CONTRACT_TYPE
 		type = CollectScience
 		title = Perform the requested experiments, take care to watch the altitude required
 
-		biome = @scienceSubject.Biome()
-		situation = @scienceSubject.Situation()
-		experiment = @scienceSubject.Experiment()
+		location = Space
+		experiment = @/experimentselect
 		recoveryMethod = @/recoveryMethod
 
-		rewardFunds = Random(1000.0, 2000.0)
+		rewardFunds = Random(6000.0, 10000.0)
 		disableOnStateChange = true
-
-		ITERATOR
-		{
-			type = ScienceSubject
-			scienceSubject = @/scienceSubjects
-		}
 	}
 
-	// Mission is no longer offered for bodies that have been orbited.
+	// Mission is no longer offered for bodies that have been landed on.
 	REQUIREMENT
 	{
-    name = Orbit
-    type = Orbit
-	invertRequirement = true
+		name = Landing
+		type = Landing
+		invertRequirement = true
 	
-    targetBody = @/targetBody
+		targetBody = @/targetBody
 	}
 	
 	// Contract only becomes available after homeworld has been orbited.


### PR DESCRIPTION
Gemini: change progress-requirement to avoid CC bugs, simplify ATV targeting datanode - now any target vessel with an ATV materials bay can be targeted.

Mariner: rebalancing (science) and change targetbody generation to make it load more often.