### PR TITLE
Update Bluedog_DB.version

### DIFF
--- a/Gamedata/Bluedog_DB/Versioning/Bluedog_DB.version
+++ b/Gamedata/Bluedog_DB/Versioning/Bluedog_DB.version
@@ -4,8 +4,8 @@
     "URL": "https://github.com/CobaltWolf/Bluedog-Design-Bureau/raw/master/Gamedata/Bluedog_DB/Versioning/Bluedog_DB.version",
     "VERSION": {
         "MAJOR": 1,
-        "MINOR": 6,
-        "PATCH": 2,
+        "MINOR": 7,
+        "PATCH": 0,
         "BUILD": 0
     },
     "KSP_VERSION": {


### PR DESCRIPTION
even though it's dev we really do want to have the versioning identified correctly for debugging