### PR TITLE
Add part switch for CoM to Gemini

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_BigG_Cabin.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_BigG_Cabin.cfg
@@ -180,6 +180,24 @@ PART
 		}
 	}
 	MODULE
+  	{
+    		name = ModuleB9PartSwitch
+    		moduleID = ReentryCoM
+		switcherDescription = CoM
+		switcherDescriptionPlural = CoM
+    		switchInFlight = True
+    		SUBTYPE
+    		{
+      		name = Normal
+      		CoMOffset = 0, 0, 0
+    		}
+    		SUBTYPE
+    		{
+      		name = Offset
+      		CoMOffset = 0, 0, 0.1
+    		}
+  	}
+	MODULE
 	{
 		name = ModuleDataTransmitter
 		antennaType = INTERNAL

--- a/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_AugustusCapsule.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_AugustusCapsule.cfg
@@ -113,7 +113,24 @@ PART
 		canTransferInVessel = True
 		showStatus = True
 	}
-	
+	MODULE
+  	{
+    		name = ModuleB9PartSwitch
+    		moduleID = ReentryCoM
+		switcherDescription = CoM
+		switcherDescriptionPlural = CoM
+    		switchInFlight = True
+    		SUBTYPE
+    		{
+      			name = Normal
+      			CoMOffset = 0, 0, 0
+    		}
+    		SUBTYPE
+    		{
+      			name = Offset
+      			CoMOffset = 0, 0, 0.1
+    		}
+  	}
 	MODULE
 	{
 		name = ModuleB9PartSwitch

--- a/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_Capsule.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_Capsule.cfg
@@ -268,7 +268,24 @@ PART
 			uiGroupDisplayName = Command
 		}
 	}
-	
+	MODULE
+  	{
+    		name = ModuleB9PartSwitch
+    		moduleID = ReentryCoM
+		switcherDescription = CoM
+		switcherDescriptionPlural = CoM
+    		switchInFlight = True
+    		SUBTYPE
+    		{
+      		name = Normal
+      		CoMOffset = 0, 0, 0
+    		}
+    		SUBTYPE
+    		{
+      		name = Offset
+      		CoMOffset = 0, 0, 0.1
+    		}
+  	}
 	MODULE
 	{
 		name = ModuleB9PartSwitch


### PR DESCRIPTION
I noticed this was a thing for Apollo, so I went ahead and copy/pasted the module for Gemini too. Gemini DID have a lifting reentry, as seen on page 8 here: https://core.ac.uk/download/pdf/85243215.pdf
Most of the entry was flown at about 10 degrees AoA, and I found in my testing that offset CoM of 0,0,0.1 is just about right to hold the capsule in that position with a little bit of RCS jostling.