### PR TITLE
Update BlueSmurff.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
@@ -22,7 +22,7 @@ BDBRESCALECONFIG
 	ballastFactorS4B = 1
 }
 
-@BDBRESCALECONFIG:NEEDS[SigmaDimensions]:FOR[zzzBluedog_DB_0]
+@BDBRESCALECONFIG:NEEDS[SigDim]:FOR[zzzBluedog_DB_0]
 {
 	@systemScale = #$@SigmaDimensions/Resize$
 }


### PR DESCRIPTION
As described on the SigmaDimensions repo itself
https://github.com/Sigma88/Sigma-Dimensions
it says
```
@Kopernicus:BEFORE[SigDim2]:NEEDS[SigDim]
{
    @Body:HAS[#name[PLANET_NAME_HERE]]
    {
        @SigmaDimensions
        {
            @PARAMETER = VALUE
        }
    }
}
```

So change NEEDS[SigmaDimensions] to NEEDS[SigDim]