### PR TITLE
Change Mercury Interstage Description

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Mercury/bluedog_Mercury_Interstage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Mercury/bluedog_Mercury_Interstage.cfg
@@ -23,7 +23,7 @@ PART
 	subcategory = 0
 	title = Hermes-Muo 1.25m Interstage
 	manufacturer = Bluedog Design Bureau
-	description = Interstage for separating the Hermes capsule from an Muo rocket.
+	description = Interstage for separating the Hermes capsule from a Bossart rocket.
 	real_title = Mercury-Atlas 1.25m Interstage
 	real_manufacturer = McDonnell Aircraft
 	real_description = Interstage for separating the Mercury capsule from an Atlas rocket. 

--- a/Gamedata/Bluedog_DB/Parts/Mercury/bluedog_Mercury_Interstage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Mercury/bluedog_Mercury_Interstage.cfg
@@ -21,7 +21,7 @@ PART
 	cost = 350
 	category = Coupling
 	subcategory = 0
-	title = Hermes-Muo 1.25m Interstage
+	title = Hermes-Bossart 1.25m Interstage
 	manufacturer = Bluedog Design Bureau
 	description = Interstage for separating the Hermes capsule from a Bossart rocket.
 	real_title = Mercury-Atlas 1.25m Interstage


### PR DESCRIPTION
This bothered me; it said "Muo rocket" when in game that's the Atlas V. Correct LV for Mercury-Atlas is "Bossart"