### PR TITLE
Fix version file URL property

### DIFF
--- a/Gamedata/Bluedog_DB/Versioning/Bluedog_DB.version
+++ b/Gamedata/Bluedog_DB/Versioning/Bluedog_DB.version
@@ -1,7 +1,7 @@
 {
     "NAME": "Bluedog Design Bureau",
     "DOWNLOAD": "https://github.com/CobaltWolf/Bluedog-Design-Bureau/releases",
-    "URL": "https://raw.githubusercontent.com/CobaltWolf/Bluedog-Design-Bureau/master/Gamedata/Bluedog_DB/Bluedog_DB.version",
+    "URL": "https://github.com/CobaltWolf/Bluedog-Design-Bureau/raw/master/Gamedata/Bluedog_DB/Versioning/Bluedog_DB.version",
     "VERSION": {
         "MAJOR": 1,
         "MINOR": 6,


### PR DESCRIPTION
The current URL property is a 404 because the Versioning folder is missing.

Fixing this will allow the BDB project to benefit from post-release updates to compatibility, e.g. if a KSP 1.11 is released and you find that the current BDB release is compatible, you can simply edit the remote version file on GitHub to make KSP-AVC and CKAN consider it compatible, without having to change the released ZIP.

@DasSkelett has written a utility that can be plugged in on GitHub to validate these files before release:

- https://github.com/DasSkelett/AVC-VersionFileValidator

Tagging @zorg2044 because GitHub doesn't take pull request notifications particularly seriously, to my continued bafflement.