### PR TITLE
Titan II improvements

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Titan/bluedog_Titan2_S2_1p25mAdapter.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Titan/bluedog_Titan2_S2_1p25mAdapter.cfg
@@ -38,4 +38,21 @@ PART
 	tags = ?sm68 Titan II 2 structural adapter 1.5 1.25
 
 	techtag = titan2
+		MODULE
+	{
+		name = ModuleDecouple
+		isOmniDecoupler = false
+		ejectionForce = 50
+		explosiveNodeID = top
+		stagingToggleEnabledEditor = True
+		stagingEnabled = false
+	}
+
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		crossfeedStatus = false
+		toggleEditor = true
+		toggleFlight = true
+	}
 }

--- a/Gamedata/Bluedog_DB/Parts/Titan/bluedog_Titan2_S2_1p5mAdapter.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Titan/bluedog_Titan2_S2_1p5mAdapter.cfg
@@ -39,4 +39,32 @@ PART
 	tags = ?sm68 Titan II 2 structural adapter 1.875 1875 1.5
 
 	techtag = titan2
+		MODULE
+	{
+		name = ModuleDecouple
+		isOmniDecoupler = false
+		ejectionForce = 100
+		explosiveNodeID = top
+		stagingToggleEnabledEditor = True
+		stagingEnabled = false
+	}
+	MODULE
+	{
+		name = ModuleDecouple
+		isOmniDecoupler = false
+		ejectionForce = 10
+		explosiveNodeID = bottom2
+		stagingToggleEnabledEditor = True
+		stagingEnabled = false
+		stagingEnableText = Middle: Enable Staging
+		stagingDisableText = Middle: Disable Staging
+	}
+
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		crossfeedStatus = false
+		toggleEditor = true
+		toggleFlight = true
+	}
 }

--- a/Gamedata/Bluedog_DB/Parts/Titan/bluedog_Titan2_S2_VernierMotor.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Titan/bluedog_Titan2_S2_VernierMotor.cfg
@@ -175,7 +175,48 @@ PART
 		amount = 12
 		maxAmount = 12
 	}
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		switcherDescription = Engine Config
+		switcherDescriptionPlural = Engine Configs
+		moduleID = engineSwitch
 
+		SUBTYPE
+		{
+			name = VTM			
+			title =	Prometheus-II-VTM Velocity Adjustment Motor
+			descriptionSummary = Small vernier solid motors originally used to trim the velocity of the Prometheus-II missile.
+			real_title = Titan II Velocity Adjustment Motor
+			real_descriptionSummary = Small vernier solid motors originally used to trim the velocity of the Titan-II missile.
+			descriptionDetail = <b>Thrust:</b> 1.9kN ASL / 2.5 kN Vac.
+			defaultSubtypePriority = 0
+		}
+
+		SUBTYPE
+		{
+			name = Sepratron
+			title = Prometheus-II-SEP Separation Motor
+			descriptionSummary = Small solid motors used to separate spent stages on the Prometheus-II missile.
+			real_title = Titan-II-SEP Separation Motor
+			real_descriptionSummary = Small solid motors used to separate spent stages on the Titan-II missile.
+			descriptionDetail = <b>Thrust:</b> 13.8 kN ASL / 18 kN Vac.
+			defaultSubtypePriority = 1
+
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+				}
+
+				DATA
+				{
+					maxThrust = 18
+				}
+			}
+		}
+	}
 	MODULE
 	{
 		name = ModuleTestSubject


### PR DESCRIPTION
- added decouplers to the Titan II 1.5m and 1.25m adapter

- added B9 variant to the Titan II vernier SRM (solid rocket motor) so it can also be used as a separation SRM.