### PR TITLE
Hexagon SCANsat integration + MOL SCANsat tweak

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
@@ -366,7 +366,7 @@
 	@description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Lo-Res Visual and basic Anomaly scanners. Requires sunlight to function.</color>:
 }
 
-@PART[bluedog_MOL_Camera,bluedog_Keyhole_Camera_KH7,bluedog_Keyhole_Camera_KH8]:FOR[BlueDog_DB]:NEEDS[SCANsat]
+@PART[bluedog_MOL_Camera,bluedog_Keyhole_Camera_KH7,bluedog_Keyhole_Camera_KH8|bluedog_Hexagon_Camera]:FOR[BlueDog_DB]:NEEDS[SCANsat]
 {
 	MODULE
 	{
@@ -396,7 +396,7 @@
 	}
 }
 //
-@PART[bluedog_Keyhole_Camera_KH1,bluedog_Keyhole_Camera_KH4,bluedog_Keyhole_Camera_KH4B]:AFTER[zzzBluedog_DB]:NEEDS[SCANsat]//AFTER zzzBluedog_DB so as not to interfere with realnames patches which might change the description
+@PART[bluedog_MOL_Camera|bluedog_Keyhole_Camera_KH1,bluedog_Keyhole_Camera_KH4,bluedog_Keyhole_Camera_KH4B|bluedog_Hexagon_Camera]:AFTER[zzzBluedog_DB]:NEEDS[SCANsat]//AFTER zzzBluedog_DB so as not to interfere with realnames patches which might change the description
 {
   @description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Hi-Res Visual and Anomaly scanners. Requires sunlight to function.</color>:
 }


### PR DESCRIPTION
Same configs as KH-4, KH-1, and MOL. Also added the description addendum to the MOL camera, which it was missing.
#997 