### PR TITLE
BDB and Kerbalism

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/OAO/bluedog_OAO_solarUpper.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/OAO/bluedog_OAO_solarUpper.cfg
@@ -123,6 +123,8 @@ PART
 				IDENTIFIER
 				{
 				name = *SolarPanel*
+				raycastTransformName = USsunCatcher
+				
 				}
 				DATA
 				{

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Mariner2_Solar_Antenna.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Mariner2_Solar_Antenna.cfg
@@ -132,6 +132,7 @@ PART
 				IDENTIFIER
 				{
 					name = *SolarPanel*
+					raycastTransformName = sunCatcher
 				}
 				DATA
 				{

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Mariner2_Solar_Basic.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Mariner2_Solar_Basic.cfg
@@ -119,6 +119,7 @@ PART
 			  IDENTIFIER
 			  {
 				name = *SolarPanel*
+				raycastTransformName = sunCatcher
 			  }
 			  DATA
 			  {

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Mariner2_TrackingSolar_Antenna.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Mariner2_TrackingSolar_Antenna.cfg
@@ -123,6 +123,7 @@ PART
 				IDENTIFIER
 				{
 					name = *SolarPanel*
+					raycastTransformName = sunCatcher
 				}
 				DATA
 				{

--- a/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Mariner2_TrackingSolar_Basic.cfg
+++ b/Gamedata/Bluedog_DB/Parts/ProbeExpansion/Ranger/bluedog_Mariner2_TrackingSolar_Basic.cfg
@@ -111,6 +111,7 @@ PART
 			  IDENTIFIER
 			  {
 				name = *SolarPanel*
+				raycastTransformName = sunCatcher
 			  }
 			  DATA
 			  {


### PR DESCRIPTION
Add a second identifier in the B9 Part Switch to fix Issue #977 . Tested both with Kerbalism and BDB and separately JNSQ and BDB to ensure that compatibility was maintained.