### PR TITLE
Apollo contract fixes

### DIFF
--- a/Gamedata/Bluedog_DB/Contracts/BDB_Apollo.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Apollo.cfg
@@ -24,9 +24,9 @@ CONTRACT_TYPE
     targetBody = @targetBody1
 
     // Contract rewards
-	advanceFunds = Random(@BluedogDB:Kerbucks105,@BluedogDB:Kerbucks2)
-    rewardFunds = Random(@BluedogDB:Kerbucks4,@BluedogDB:Kerbucks5)
-    rewardReputation = Random(10.0, 15.0)
+	advanceFunds = Random(@BluedogDB:Kerbucks4,@BluedogDB:Kerbucks5)
+    rewardFunds = Random(@BluedogDB:Kerbucks8,@BluedogDB:Kerbucks9)
+    rewardReputation = Random(20.0, 25.0)
 
 	// Randomly select a possible target body.
     DATA
@@ -97,7 +97,7 @@ CONTRACT_TYPE
 		{
 			name = Kane Landing Site
 			hidden = False
-			targetBody = HomeWorld().Children().First()
+			targetBody = @/targetBody
 			count = 1
 			icon = marker
 			altitude = 0.0
@@ -158,21 +158,11 @@ CONTRACT_TYPE
 			name = Orbit
 			type = Orbit
 			targetBody = @/targetBody
-			maxApA = 0.3 * @/targetBody.Radius()
-			maxPeA = 0.05 * @/targetBody.Radius()
+			maxApA = 0.4 * @/targetBody.Radius()
+			maxPeA = 0.2 * @/targetBody.Radius()
 			minEccentricity = 0.07
 			title = Establish a low, elliptic orbit around @targetBody
 			disableOnStateChange = true
-		}
-
-		PARAMETER
-		{    
-			name = Docking    
-			type = Docking    
-			vessel = Kane-LM
-			disableOnStateChange = true
-			completeInSequence = true
-			title = Dock with the Lunar Module after it has completed its mission on the surface of @/targetBody
 		}
 	}
 
@@ -228,8 +218,8 @@ CONTRACT_TYPE
 			name = Orbit
 			type = Orbit
 			targetBody = @/targetBody
-			maxApA = 0.1 * @targetBody.Radius()
-			maxPeA = 0.05 * @targetBody.Radius()
+			maxApA = 0.2 * @/targetBody.Radius()
+			maxPeA = 0.1 * @/targetBody.Radius()
 			disableOnStateChange = true
 			title = Have the LM pass at low altitude before landing
 		}
@@ -329,8 +319,8 @@ CONTRACT_TYPE
 			name = Orbit
 			type = Orbit
 			targetBody = @/targetBody
-			maxApA = 0.3 * @targetBody.Radius()
-			maxPeA = 0.05* @targetBody.Radius()
+			maxApA = 0.4 * @/targetBody.Radius()
+			maxPeA = 0.2 * @/targetBody.Radius()
 			disableOnStateChange = true
 			title = Release Kane-PFS into a similar orbit as established by the main spacecraft
 		}


### PR DESCRIPTION
Improved rewards to compensate for high parts unlock costs of Saturn stuff; fix waypoint generation; increase target orbital height to avoid unsafe altitudes better; removed docking objective due CC not recognizing it always.