### PR TITLE
Fix bulkheadProfiles missing commas

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Agena/bluedog_Keyhole_RVAdapter.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Agena/bluedog_Keyhole_RVAdapter.cfg
@@ -37,7 +37,7 @@ PART
 	fuelCrossFeed = False
 	stageOffset = 1
 	childStageOffset = 1
-	bulkheadProfiles = size0p5 size0
+	bulkheadProfiles = size0p5, size0
 	stagingIcon = DECOUPLER_HOR
 	breakingForce = 28
 	breakingTorque = 28

--- a/Gamedata/Bluedog_DB/Parts/Hexagon/bluedog_Hexagon_AdapterSegment.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Hexagon/bluedog_Hexagon_AdapterSegment.cfg
@@ -45,7 +45,7 @@ PART
 	fuelCrossFeed = False
 	stageOffset = 1
 	childStageOffset = 1
-	bulkheadProfiles = size0p5 size0
+	bulkheadProfiles = size0p5, size0
 	stagingIcon = DECOUPLER_HOR
 	breakingForce = 28
 	breakingTorque = 28

--- a/Gamedata/Bluedog_DB/Parts/Hexagon/bluedog_Hexagon_TrussSegment.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Hexagon/bluedog_Hexagon_TrussSegment.cfg
@@ -45,7 +45,7 @@ PART
 	fuelCrossFeed = False
 	stageOffset = 1
 	childStageOffset = 1
-	bulkheadProfiles = size0p5 size0
+	bulkheadProfiles = size0p5, size0
 	stagingIcon = DECOUPLER_HOR
 	breakingForce = 28
 	breakingTorque = 28


### PR DESCRIPTION
A handful of adapters between size 0 and size 0.5 have bulkheadProfiles as "size0p5 size0". I assume this is a case of a missing comma, so I went ahead and made these corrections.

Credit to linuxgurugamer for dragging through every bulkheadProfile he could get his hands on and identify "size0p5 size0" as a profile being used.