### PR TITLE
Update KSP_VERSION_MIN to 1.8.0 in version file

### DIFF
--- a/Gamedata/Bluedog_DB/Versioning/Bluedog_DB.version
+++ b/Gamedata/Bluedog_DB/Versioning/Bluedog_DB.version
@@ -15,8 +15,8 @@
     },
     "KSP_VERSION_MIN": {
         "MAJOR": 1,
-        "MINOR": 7,
-        "PATCH": 3
+        "MINOR": 8,
+        "PATCH": 0
     },
     "KSP_VERSION_MAX": {
         "MAJOR": 1,


### PR DESCRIPTION
If I understood this comment and the discussion that followed on the forum thread correctly, the mod actually has a minimum KSP version requirement of 1.8.0:
* https://forum.kerbalspaceprogram.com/index.php?/topic/122020-181-1101-bluedog-design-bureau-stockalike-saturn-apollo-and-more-v171-%D0%BE%D0%B3%D1%80%D0%BE%D0%BC%D0%BD%D1%8B%D0%B9-18oct2020/&do=findComment&comment=3936769

It has not been 100% confirmed by @zorg2044, but I though I might just do a PR and see.

This bumps the minimum KSP version for the current release to 1.8.0 in the version file. Since CKAN considers remote version files (as long as the "URL" is correct), it will detect the change and subsequently update the metadata of the latest release.

We can  fix it for older releases as well, but you'd need to tell me which version to change to what.
Right now it's as follows:
![image](https://user-images.githubusercontent.com/28812678/110218583-c6d81980-7eba-11eb-8862-d20f7b92ed6e.png)

Feel free to close if BDB actually works fine on KSP 1.7.3.