### PR TITLE
Update bluedog_Gemini_LunarRecon_Camera.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_LunarRecon_Camera.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_LunarRecon_Camera.cfg
@@ -27,7 +27,7 @@ MODEL
 	TechRequired = generalConstruction
 	entryCost = 3750
 	cost = 1710
-	category     = Coupling
+	category     = Science
 	subcategory  = 0
 	title        = Leo-XP-NRC Nose Camera
 	manufacturer = Trails Manufacturing Co.


### PR DESCRIPTION
The Gemini Lunar Recon Camera is not a docking port
Changes category from "Coupling" to "science"