### PR TITLE
Update AtlasSurfaceAttach.cfg

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/AtlasSurfaceAttach/AtlasSurfaceAttach.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/AtlasSurfaceAttach/AtlasSurfaceAttach.cfg
@@ -1,5 +1,29 @@
+// Origional Patch by Zorg, edited by Pappystein.  Note this patch does not currently allow decal placement on the CELV or SLV3X parts.
+// that will require significant editing in the modles I believe.  For this same reason the Bossart Atlas main tank (with the side saddles) does not
+// support decales inspite of this patch.
+
 // Patch for users who want to surface attach to Atlas tanks. We better not see you use it for things other than decals ;)
-@PART[bluedog*,Bluedog*]:HAS[#bdbTankType[bdbBalloon]]:AFTER[Bluedog_DB]
+
+// This updates Zorg's origional patch to isolate just atlas rocket parts and not other Balloon tanked parts.
+//   It is an alternative to an earlier suggestion I made on the subject, to prevent "cross talk" between rockets that are patched with variables.
+// As with Zorg's origional patch this only works for fuel containing tanks that are of the TankType bdbBalloon.   But now it is also rocket family discriminatory
+
+//Atlas Bossart  parts
+@PART[bluedog*,Bluedog*]:HAS[bluedog_Atlas*,#bdbTankType[bdbBalloon]]:AFTER[Bluedog_DB]
 {
 	@attachRules = 1,0,1,1,0
 }
+
+//Atlas CELV parts
+@PART[bluedog*,Bluedog*]:HAS[bluedog_CELV*,#bdbTankType[bdbBalloon]]:AFTER[Bluedog_DB]
+{
+	@attachRules = 1,0,1,1,0
+}
+
+//Atlas SLV3X parts
+@PART[bluedog*,Bluedog*]:HAS[bluedog_SLV3X*,#bdbTankType[bdbBalloon]]:AFTER[Bluedog_DB]
+{
+	@attachRules = 1,0,1,1,0
+}
+
+


### PR DESCRIPTION
Fixes issue with non-Bossart Balloon tanks not working correctly.   HOWEVER, while the patch has room for CELV and SLV3X parts, the existing models do not support the colliders as they are assigned.

