### PR TITLE
Add engine mount node for HGA

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_SPS.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_SPS.cfg
@@ -19,7 +19,7 @@ MODEL
 	subcategory = 0
 	title = Kane-11-SE60 Service Propulsion System
 	manufacturer = Bluedog Design Bureau
-	description = This massive service engine sacrifices much of its power to eliminate weight. The result is a very light, though not extremely efficient, propulsion system for large orbiters in the 2.5m size class and up. Includes a mounting point for a high gain antenna system.
+	description = This massive service engine sacrifices much of its power to eliminate weight. The result is a very light, though not extremely efficient, propulsion system for large orbiters in the 2.5m size class and up.
 	real_title = AJ10-137 Apollo Service Propulsion System
 	real_manufacturer = Aerojet
 	attachRules = 1,0,1,1,0

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_highGain.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_Block2_highGain.cfg
@@ -9,6 +9,7 @@ MODEL
 }
 	scale = 1
 	rescaleFactor = 1
+	node_stack_side = -0.091, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 	node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
 	TechRequired = commandModules
 	entryCost = 1500
@@ -17,11 +18,11 @@ MODEL
 	subcategory = 0
 	title = Kane-11-CDA High Gain Antenna
 	manufacturer = Bluedog Design Bureau
-	description = A collapsible relay antenna consisting of four high gain dishes, for transmitting the many exciting things you've discovered. Intended to be placed on the mounting bracket of the Kane-11 service engine.
+	description = A collapsible relay antenna consisting of four high gain dishes, for transmitting the many exciting things you've discovered. Intended to be placed on the mounting bracket of the Kane-11 engine mount.
 	real_title = Apollo S-Band High Gain Antenna
 	real_manufacturer = Collins Radio
 	// Source: https://www.ab9il.net/aviation/apollo-s-band.html
-	real_description = A collapsable relay antenna consisting of four high gain dishes, for transmitting the many exciting things you've discovered. Intended to be placed on the mounting bracket of the Apollo service engine.
+	real_description = A collapsable relay antenna consisting of four high gain dishes, for transmitting the many exciting things you've discovered. Intended to be placed on the mounting bracket of the Apollo engine mount.
 	attachRules = 1,1,0,0,1
 	mass = 0.08
 	dragModelType = default

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_DrogueChute.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_DrogueChute.cfg
@@ -31,9 +31,10 @@
 	cost = 200
 	category = Utility
 	subcategory = 0
-	title = Leo-M-8DC Drogue Parachute
-	description = Drogue parachute for the Leo capsule. Attach to the node in the nose section.
-	real_title = Gemini Drogue Parachute
+	title = Kane-11 Drogue Parachute
+	description = Drogue parachute for the Kane-11 Command Pod. Attach to the node in the nose section.
+	real_title = Apollo Drogue Parachute
+	real_description = Drogue parachute for the Apollo Command Module. Attach to the node in the nose section.
 	attachRules = 1,0,0,1,0
 	mass = 0.02
 	dragModelType = default

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_EngineMount.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_EngineMount.cfg
@@ -13,6 +13,7 @@ PART
 	node_stack_top = 0.0, 0.131, 0.0, 0.0, 1.0, 0.0, 1
 	node_stack_bottom = 0.0, 0.08508, 0.0, 0.0, -1.0, 0.0, 1
 	node_stack_engine = 0.0, -0.05937304, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_antenna = -0.7065, 0.029, 0.7065, 1.0, 0.0, -1.0, 0
 
 	TechRequired = generalRocketry
 	entryCost = 2500
@@ -21,10 +22,10 @@ PART
 	subcategory = 0
 	title = Kane-11-EMT 2.5m Engine Mount
 	manufacturer = Bluedog Design Bureau
-	description = Mounting plate for attaching a single engine to 1.25m tanks. Includes a node just below the top rim for attaching the interstage fairing.
+	description = Mounting plate for attaching a single engine to 2.5m tanks. Includes a node just below the top rim for attaching the Sarnus LAM as well as a mounting point for the high gain antenna system.
 	real_title = Apollo CSM 2.5m Engine Mount
 	real_manufacturer = North American
-	real_description = Mounting plate for attaching a single engine to 2.5m tanks. Includes a node just below the top rim for attaching the interstage fairing.
+	real_description = Mounting plate for attaching a single engine to 2.5m tanks. Includes a node just below the top rim for attaching the Saturn SLA as well as a mounting point for the high gain antenna system.
 	attachRules = 1,0,1,1,0
 	mass = 0.025
 	dragModelType = default

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_MainChute.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_MainChute.cfg
@@ -30,9 +30,10 @@
 	cost = 200
 	category = Utility
 	subcategory = 0
-	title = Hermes-MASD Main Parachute
-	description = Main parachute for the Hermes capsule. Attach to the node in the recovery section.
-	real_title = Mercury-MASD Main Parachute
+	title = Kane-11 Main Parachute
+	description = Main parachute for the Kane-11 Command Pod. Attach to the node in the nose section.
+	real_title = Apollo Main Parachute
+	real_description = Main parachute for the Apollo Command Module. Attach to the node in the nose section.
 	attachRules = 1,0,0,1,0
 	mass = 0.02
 	dragModelType = default

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_ParachuteCover.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_Apollo_ParachuteCover.cfg
@@ -18,10 +18,10 @@ MODEL
 	category = Structural
 	subcategory = 0
 	title = Kane-11-PMX3 1.25m Parachute Cover
-	description = Structural adapter for Kane parachutes and docking port. Place on top of the capsule, add parachutes in 3x symmetry. The Active Docking Mechanism goes on top. Includes a decoupler for the docking mechanism, to clear the way for the parachutes.
-	real_title = Apollo 1.25m Parachute Mount
+	description = Structural cover for Kane parachutes. Place on top of the capsule after adding the main and drogue parachutes. The Active Docking Mechanism goes on top. Includes a decoupler to clear the way for the parachutes.
+	real_title = Apollo 1.25m Parachute Cover
 	real_manufacturer = North American Rockwell
-	real_description = Structural adapter for Apollo parachutes and docking port. Place on top of the capsule, add parachutes in 3x symmetry. The Active Docking Mechanism goes on top. Includes a decoupler for the docking mechanism, to clear the way for the parachutes.
+	real_description = Structural cover for Apollo parachutes. Place on top of the capsule after adding the main and drogue parachutes. The Active Docking Mechanism goes on top. Includes a decoupler to clear the way for the parachutes.
 	attachRules = 1,0,1,1,0
 	mass = 0.02
 	dragModelType = default
@@ -41,13 +41,11 @@ MODEL
 	tags = arrest blue canopy chute decel descen drag entry fall landing re- return safe slow Apollo Kane block ?1 ?2 ?3 ?4 ?5 ?i ?ii ?iii ?iv ?v  CSMTEST
   techtag = apolloGen1
   
-		MODULE
+	MODULE
 	{
 		name = ModuleDecouple
 		isOmniDecoupler = false
 		ejectionForce = 30
 		explosiveNodeID = bottom
 	}
-
-	
 }


### PR DESCRIPTION
Added a node to the SPS engine mount and the high-gain antenna for easier assembly.

Also changed some titles and descriptions that were wrong. Both the drogue and main parachutes still need a proper designation though.