### PR TITLE
Add densified propellants for Delta IV to BD_Extras

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/delta_propellant_densification/delta_propellant_densification.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/delta_propellant_densification/delta_propellant_densification.cfg
@@ -1,3 +1,7 @@
+// Adds options for densified propellants for Delta IV tanks from 'DELTA IV LAUNCH VEHICLE GROWTH OPTIONS TO SUPPORT NASA’S SPACE EXPLORATION VISION'
+// Assumes 9% increase, based off 'Recent Advances and Applicationsin Cryogenic Propellant Densification Technology'
+// by EStreetRockets
+
 @PART[bluedog_DeltaIV_s1_lowerTank]:BEFORE[Bluedog_DB]
 {
     MODULE

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/delta_propellant_densification/delta_propellant_densification.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/delta_propellant_densification/delta_propellant_densification.cfg
@@ -1,0 +1,84 @@
+@PART[bluedog_DeltaIV_s1_lowerTank]:BEFORE[Bluedog_DB]
+{
+    MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = volumeSwitch
+		switcherDescription = Propellant Volume
+		switcherDescriptionPlural = Propellant Volume
+		parentID:NEEDS[!RealFuels] = fuelSwitch
+		SUBTYPE
+		{
+			name = Baseline
+		}
+
+		SUBTYPE
+		{
+			name = Densified Propellant
+			volumeAddedToParent:NEEDS[!RealFuels] = 7290
+		}
+	}
+}
+@PART[bluedog_DeltaIV_s1_upperTank]:BEFORE[Bluedog_DB]
+{
+    MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = volumeSwitch
+		switcherDescription = Propellant Volume
+		switcherDescriptionPlural = Propellant Volume
+		parentID:NEEDS[!RealFuels] = fuelSwitch
+		SUBTYPE
+		{
+			name = Baseline
+		}
+
+		SUBTYPE
+		{
+			name = Densified Propellant
+			volumeAddedToParent:NEEDS[!RealFuels] = 2430
+		}
+	}
+}
+@PART[bluedog_DeltaIV_DCSS_5m]:BEFORE[Bluedog_DB]
+{
+    MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = volumeSwitch
+		switcherDescription = Propellant Volume
+		switcherDescriptionPlural = Propellant Volume
+		parentID:NEEDS[!RealFuels] = fuelSwitch
+		SUBTYPE
+		{
+			name = Baseline
+		}
+
+		SUBTYPE
+		{
+			name = Densified Propellant
+			volumeAddedToParent:NEEDS[!RealFuels] = 1296
+		}
+	}
+}
+@PART[bluedog_DCSS_Tank]:BEFORE[Bluedog_DB]
+{
+    MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = volumeSwitch
+		switcherDescription = Propellant Volume
+		switcherDescriptionPlural = Propellant Volume
+		parentID:NEEDS[!RealFuels] = fuelSwitch
+		SUBTYPE
+		{
+			name = Baseline
+		}
+
+		SUBTYPE
+		{
+			name = Densified Propellant
+			volumeAddedToParent:NEEDS[!RealFuels] = 813.6
+		}
+	}
+}

--- a/Gamedata/Bluedog_DB/Parts/SAF_Fairings/bluedog_Strawman_Bus_SAF.cfg
+++ b/Gamedata/Bluedog_DB/Parts/SAF_Fairings/bluedog_Strawman_Bus_SAF.cfg
@@ -109,9 +109,6 @@ PART:NEEDS[Bluedog_DB/Parts/Agena]
 		transform = Juno4_125_Nose
 		transform = Juno4_125_Cap
 	}
-
-	hasHibernation = True
-	}
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/Gamedata/Bluedog_DB/Parts/SAF_Fairings/bluedog_Strawman_Bus_SAF.cfg
+++ b/Gamedata/Bluedog_DB/Parts/SAF_Fairings/bluedog_Strawman_Bus_SAF.cfg
@@ -110,6 +110,8 @@ PART:NEEDS[Bluedog_DB/Parts/Agena]
 		transform = Juno4_125_Cap
 	}
 
+	hasHibernation = True
+	}
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/Gamedata/Bluedog_DB/Parts/SAF_Fairings/bluedog_Strawman_Bus_SAF.cfg
+++ b/Gamedata/Bluedog_DB/Parts/SAF_Fairings/bluedog_Strawman_Bus_SAF.cfg
@@ -109,6 +109,7 @@ PART:NEEDS[Bluedog_DB/Parts/Agena]
 		transform = Juno4_125_Nose
 		transform = Juno4_125_Cap
 	}
+
 	RESOURCE
 	{
 		name = ElectricCharge


### PR DESCRIPTION
Adds options for densified propellants for Delta IV tanks from 'DELTA IV LAUNCH VEHICLE GROWTH OPTIONS TO SUPPORT NASA’S SPACE EXPLORATION VISION'
Assumes 9% increase, based off 'Recent Advances and Applicationsin Cryogenic Propellant Densification Technology'