### PR TITLE
Contracts scidef patch fix

### DIFF
--- a/Gamedata/Bluedog_DB/Contracts/BDB_AIMP.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_AIMP.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Target any body that has been reached, except homeworld.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -51,7 +53,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Apollo.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Apollo.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Target any body without atmosphere that has been landed on.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Corona_KH1.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Corona_KH1.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Any body that has been reached can be targeted.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -51,7 +53,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 
@@ -74,7 +77,6 @@ CONTRACT_TYPE
     DATA
     {
 		type = ScienceRecoveryMethod
-
         hidden = true
 
         recoveryMethod = Recover

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Corona_KH4.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Corona_KH4.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Any body that has been reached can be targeted.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -51,7 +53,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 
@@ -74,7 +77,6 @@ CONTRACT_TYPE
     DATA
     {
 		type = ScienceRecoveryMethod
-
         hidden = true
 
         recoveryMethod = Recover

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Gambit.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Gambit.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Any body that has been reached can be targeted.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -51,7 +53,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 
@@ -74,7 +77,6 @@ CONTRACT_TYPE
     DATA
     {
 		type = ScienceRecoveryMethod
-
         hidden = true
 
         recoveryMethod = Recover

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Gemini.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Gemini.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -43,7 +44,8 @@ CONTRACT_TYPE
 	// Any body from which we have orbited.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -184,6 +186,7 @@ CONTRACT_TYPE
     DATA
     {
         name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -194,6 +197,7 @@ CONTRACT_TYPE
 	DATA
     {
         name = targetatv
+		title = targetatv
 		type = Vessel
 		requiredValue = true
         targetVessel1 = AllVessels().Where(v => v.Parts().Contains(bluedog_GATV_MaterialsBay) == true).Random()
@@ -204,6 +208,7 @@ CONTRACT_TYPE
     DATA
     {
         name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 
@@ -214,7 +219,6 @@ CONTRACT_TYPE
     DATA
     {
 		type = ScienceRecoveryMethod
-
         hidden = true
 
         recoveryMethod = Recover

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Lunar_Orbiter.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Lunar_Orbiter.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Target any body that has been orbited, except homeworld.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -51,7 +53,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Mariner.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Mariner.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -42,7 +43,8 @@ CONTRACT_TYPE
 	// Target the next unreached body in logical progression.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
 		hidden = true
 	
@@ -56,7 +58,8 @@ CONTRACT_TYPE
     //Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 	

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Nimbus.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Nimbus.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Only bodies with Atmosphere can be targeted.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -51,7 +53,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 
@@ -75,7 +78,6 @@ CONTRACT_TYPE
     DATA
     {
 		type = ScienceRecoveryMethod
-
         hidden = true
 
         recoveryMethod = Transmit

--- a/Gamedata/Bluedog_DB/Contracts/BDB_OGO.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_OGO.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Any body that has been reached can be targeted.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -51,7 +53,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 
@@ -76,7 +79,6 @@ CONTRACT_TYPE
     DATA
     {
 		type = ScienceRecoveryMethod
-
         hidden = true
 
         recoveryMethod = Transmit

--- a/Gamedata/Bluedog_DB/Contracts/BDB_OGO.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_OGO.cfg
@@ -55,7 +55,7 @@ CONTRACT_TYPE
 		type = List<ScienceExperiment>
         hidden = true
 
-        experiments = [bd_ionElec , gravityScan , logIonTrap , bd_gammaRay, bd_magScan , bd_massSpec]
+        experiments = [bd_cosmicRay , gravityScan , logIonTrap , bd_gammaRay, bd_magScan , bd_massSpec]
 		experimentslow = @experiments.Random(2)
     }
 	

--- a/Gamedata/Bluedog_DB/Contracts/BDB_OSO.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_OSO.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Any body that has been orbited can be targeted.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -51,7 +53,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 
@@ -75,7 +78,6 @@ CONTRACT_TYPE
     DATA
     {
 		type = ScienceRecoveryMethod
-
         hidden = true
 
         recoveryMethod = Transmit

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Ranger Block 2.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Ranger Block 2.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Target any body without atmosphere that has been reached.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -52,7 +54,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 
@@ -74,7 +77,7 @@ CONTRACT_TYPE
 	//The possible biomes for the target body.
     DATA
     {
-        title = biomelist
+		title = biomelist
 		type = List<Biome>
         biomes = @targetBody.Biomes()
         hidden = true

--- a/Gamedata/Bluedog_DB/Contracts/BDB_Ranger.cfg
+++ b/Gamedata/Bluedog_DB/Contracts/BDB_Ranger.cfg
@@ -31,7 +31,8 @@ CONTRACT_TYPE
 	// Randomly select a possible target body.
     DATA
     {
-        title = target
+        name = target
+		title = target
 		type = CelestialBody
 		hidden = true
 		
@@ -41,7 +42,8 @@ CONTRACT_TYPE
 	// Target any body without atmosphere that has been reached.
 	DATA
     {
-        title = bodieslist
+        name = bodieslist
+		title = bodieslist
 		type = List<CelestialBody>
         hidden = true
 
@@ -52,7 +54,8 @@ CONTRACT_TYPE
     // Hardcoded list of specific experiments
     DATA
     {
-        title = experimentslist
+        name = experimentslist
+		title = experimentslist
 		type = List<ScienceExperiment>
         hidden = true
 
@@ -74,7 +77,7 @@ CONTRACT_TYPE
 	//The possible biomes for the target body.
     DATA
     {
-        title = biomelist
+		title = biomelist
 		type = List<Biome>
         biomes = @targetBody.Biomes()
         hidden = true


### PR DESCRIPTION
Scidef patches to data nodes were not being applied after the name fields got changed to title fields. Added name fields back in while keeping titles, to fix MM patching them.