### PR TITLE
Scale Bluesmurff to support RSS (10.6x Kerbbin)

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
@@ -54,22 +54,21 @@ BDBRESCALECONFIG
     @systemScale = 2.7
 }
 
-
-@BDBRESCALECONFIG:HAS[#systemScale[>6.4]]:BEFORE[zzzBluedog_DB_1]
-{
-	@systemScale = 6.4 // Adjustments are not valid beyond this scale
-}
-
 @BDBRESCALECONFIG:NEEDS[!SigmaDimensions,RealSolarSystem]:FOR[zzzBluedog_DB_0]
 {
-	@systemScale = 6.4 // Adjustments are not valid beyond this scale
+	@systemScale = 10.6 // Adjustments are not valid beyond this scale
+}
+
+@BDBRESCALECONFIG:HAS[#systemScale[>10.6]]:BEFORE[zzzBluedog_DB_1]
+{
+	@systemScale = 10.6 // Adjustments are not valid beyond this scale
 }
 
 @BDBRESCALECONFIG:BEFORE[zzzBluedog_DB_1]
 {
 	%scaleFactor = #$systemScale$
 	@scaleFactor -= 1
-	@scaleFactor /= 5.4
+	@scaleFactor /= 9.6
 }
 
 @PART[bluedog*,Bluedog*]:FOR[zzzBluedog_DB_1]
@@ -90,7 +89,7 @@ BDBRESCALECONFIG
 
 @BDBRESCALECONFIG:HAS[#systemScale[>2.9]]:FOR[zzzBluedog_DB_1]
 {
-	%tankSubtract = 0.59
+	%tankSubtract = 0.76
 	@tankSubtract *= #$scaleFactor$
 	@tankFactor -= #$tankSubtract$
 }
@@ -104,7 +103,7 @@ BDBRESCALECONFIG
 
 @BDBRESCALECONFIG:HAS[#systemScale[>3.9]]:FOR[zzzBluedog_DB_1]
 {
-	%engineSubtract = 0.59
+	%engineSubtract = 0.76
 	@engineSubtract *= #$scaleFactor$
 	@engineFactor -= #$engineSubtract$
 }


### PR DESCRIPTION
The current BLUESMURFF can balance well up to 6.4x, but fall fairly short for 10.6x that is the scale of the RealSolarSystem. This change should extend the balance toward 10.6x scale world, slightly less advantageous in smaller worlds like 6.4x and 2.5x, however, more consistent with the actual SMURFF mod that rebalance the other mods for 10.6x world.

There are going to have couple of errors for Vega_Upper_StageTank and Titan2_S1_UpperTank when SMURFF is installed, I think it is a bug on the SMURFF part since SMURFF isn't supposed to change the part anyway.