### PR TITLE
Scale BLUESMURFF to handle RSS (10.6X scale)

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
@@ -11,6 +11,7 @@ BDBRESCALECONFIG
 {
 	systemScale = 1
 	tankFactor = 1
+	srbFactor = 1
 	structFactor = 1
 	podFactor = 1
 	apolloPodFactor = 1
@@ -30,6 +31,10 @@ BDBRESCALECONFIG
 {
 	@systemScale = #$@SigmaDimensions/Resize$
 	@systemScale /= 0.0941767383456286 // Kerbin radius/Earth radius. For downsized RSS setups like SSRSS.
+}
+@BDBRESCALECONFIG:NEEDS[!SigmaDimensions,RealSolarSystem]:FOR[zzzBluedog_DB_0]
+{
+	@systemScale = 10.6 // Adjustments are not valid after 10.6
 }
 @BDBRESCALECONFIG:NEEDS[HarderSolarSystem-2x]:FOR[zzzBluedog_DB_0]
 {
@@ -54,22 +59,16 @@ BDBRESCALECONFIG
     @systemScale = 2.7
 }
 
-
-@BDBRESCALECONFIG:HAS[#systemScale[>6.4]]:BEFORE[zzzBluedog_DB_1]
+@BDBRESCALECONFIG:HAS[#systemScale[>10.6]]:BEFORE[zzzBluedog_DB_1]
 {
-	@systemScale = 6.4 // Adjustments are not valid beyond this scale
-}
-
-@BDBRESCALECONFIG:NEEDS[!SigmaDimensions,RealSolarSystem]:FOR[zzzBluedog_DB_0]
-{
-	@systemScale = 6.4 // Adjustments are not valid beyond this scale
+	@systemScale = 10.6 // Adjustments are not valid beyond this scale
 }
 
 @BDBRESCALECONFIG:BEFORE[zzzBluedog_DB_1]
 {
 	%scaleFactor = #$systemScale$
 	@scaleFactor -= 1
-	@scaleFactor /= 5.4
+	@scaleFactor /= 9.6
 }
 
 @PART[bluedog*,Bluedog*]:FOR[zzzBluedog_DB_1]
@@ -79,7 +78,7 @@ BDBRESCALECONFIG
 
 @BDBRESCALECONFIG:HAS[#systemScale[>1]]:FOR[zzzBluedog_DB_1]
 {
-	%podSubtract = 0.5
+	%podSubtract = 0.644
 	@podSubtract *= #$scaleFactor$
 	@podFactor -= #$podSubtract$
 	%apolloPodFactor = #$podFactor$
@@ -90,28 +89,35 @@ BDBRESCALECONFIG
 
 @BDBRESCALECONFIG:HAS[#systemScale[>2.9]]:FOR[zzzBluedog_DB_1]
 {
-	%tankSubtract = 0.59
+	%tankSubtract = 0.76
 	@tankSubtract *= #$scaleFactor$
 	@tankFactor -= #$tankSubtract$
 }
 
+@BDBRESCALECONFIG:HAS[#systemScale[>2.9]]:FOR[zzzBluedog_DB_1]
+{
+	%srbSubtract = 0.515
+	@srbSubtract *= #$scaleFactor$
+	@srbFactor -= #$srbSubtract$
+}
+
 @BDBRESCALECONFIG:HAS[#systemScale[>3.9]]:FOR[zzzBluedog_DB_1]
 {
-	%structSubtract = 0.50
+	%structSubtract = 0.644
 	@structSubtract *= #$scaleFactor$
 	@structFactor -= #$structSubtract$
 }
 
 @BDBRESCALECONFIG:HAS[#systemScale[>3.9]]:FOR[zzzBluedog_DB_1]
 {
-	%engineSubtract = 0.59
+	%engineSubtract = 0.76
 	@engineSubtract *= #$scaleFactor$
 	@engineFactor -= #$engineSubtract$
 }
 
 @BDBRESCALECONFIG:HAS[#systemScale[>6]]:FOR[zzzBluedog_DB_1]
 {
-	@apolloPodFactor = 0.4
+	@apolloPodFactor = 0.515
 	
 	%ballastFactorS1C = 1
 	%ballastFactorS2 = 0.5
@@ -256,6 +262,7 @@ BDBRESCALECONFIG
 }
 
 // Bring solids up from 19% to 26% scale by mass.
+
 @PART[bluedog_Delta_GEM*,bluedog_Diamant_*,bluedog_castorSRB,bluedog_alcyone,bluedog_Castor*,bluedog_star*,bluedog_Soltan_*,bluedog_Titan_SRB*]:HAS[#bdbSystemScale[>6],@RESOURCE[SolidFuel],~bdbMassAdjusted[*]]:FOR[zzzBluedog_DB_3]
 {
 	@mass *= 1.368
@@ -269,6 +276,38 @@ BDBRESCALECONFIG
 		@maxAmount *= 1.368
 	}
 }
+
+// Rebalance the upper solids for 10.6X world.
+@PART[bluedog_UpperSolids_*,bluedog_Sergeant_*,bluedog_Scout_Antares_*]:HAS[#bdbSystemScale[>10],@MODULE[ModuleEngines*]:HAS[@PROPELLANT[SolidFuel]],~bdbMassAdjusted[*]]:FOR[zzzBluedog_DB_3]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 1.75
+	}
+	@mass *= 1.75
+	@RESOURCE[SolidFuel]
+	{
+		@amount *= 1.75
+		@maxAmount *= 1.75
+	}
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+	{
+		@SUBTYPE[*],*
+		{
+			@addedMass *= 1.75
+			@volumeAdded *= 1.75
+			@MODULE
+			{
+				@DATA
+				{
+					@maxThrust *= 1.75
+				}
+			}
+		}
+	}
+}
+// --------
+
 
 //// Castor 30/120. Athena neeeds a little less dry mass in addition to basic adjustment
 @PART[bluedog_Castor30,bluedog_Castor120]:HAS[#bdbSystemScale[>6],@RESOURCE[SolidFuel]]:FOR[zzzBluedog_DB_7]
@@ -353,8 +392,8 @@ BDBRESCALECONFIG
 
 @PART[bluedog*,Bluedog*]:HAS[#bdbSystemScale[>1],@MODULE[ModuleEngines*]:HAS[@PROPELLANT[SolidFuel]],~bdbMassAdjusted[*]]:FOR[zzzBluedog_DB_5]
 {
-	@mass *= #$@BDBRESCALECONFIG/tankFactor$
-	%bdbMassAdjusted = #$@BDBRESCALECONFIG/tankFactor$
+	@mass *= #$@BDBRESCALECONFIG/srbFactor$
+	%bdbMassAdjusted = #$@BDBRESCALECONFIG/srbFactor$
 }
 
 //@PART[bluedog*,Bluedog*]:HAS[#bdbSystemScale[>1],@MODULE[ModuleEngines*]:HAS[@PROPELLANT[SolidFuel]],~bdbSrbAdjusted[*]]:FOR[zzzBluedog_DB_5]


### PR DESCRIPTION
The original BLUESMURFF was designed to handle 6.4x world, but fell short on 10.6x world, e.g., this scale alone cannot lift Explorer-1 to the historical orbit (2550 x 358KM), so I further scaled this to the full SMURFF mod: dry mass reduction of 76% for liquid engine tank, 50% drymass reduction for SRB (40% in SMURFF, but we don't have that 40 ISP improvement).  I also need to boost some of the small kicker SRBs to reach reasonable thrust to payload ratio to so that Juno-I and Vanguard-I can reach orbit (Vanguard can have a vacuum DeltaV of 10km/s).