### PR TITLE
Typo in naming a MODULE. KIS patch

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/KIS/KIS.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/KIS/KIS.cfg
@@ -135,7 +135,7 @@
 		defaultMoveSndPath = KIS/Sounds/itemMove
 	}
 
-	%MODULE[name = ModuleKISItem]
+	%MODULE[ModuleKISItem]
 	{
 		volumeOverride = 410
 		stackable = false


### PR DESCRIPTION
Fixed a syntax typo error in KIS patch