### PR TITLE
CryoTanks optional extra patch

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/CryoTanks/CryoTanks.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/CryoTanks/CryoTanks.cfg
@@ -1,0 +1,58 @@
+// Replaces BDB boiloff mechanics with CryoTanks boiloff mechanics if CryoTanks is installed.
+// Please note that CryoTanks boiloff mechanics are simpler and significantly more relaxed 
+// than the ones in BDB.
+//
+// author: Grimmas
+//
+
+@PART[*]:HAS[@MODULE[ModuleBdbBoiloff]]:NEEDS[CryoTanks,Bluedog_DB]:FOR[zzz_CryoTanks] 
+{
+	// delete BDB boiloff module
+	!MODULE[ModuleBdbBoiloff] {}
+	
+	// Remove reference to boiloff module from some switches.
+	// Can still jettison insulation to shed mass.
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[insulationSwitch]] 
+	{
+		@SUBTYPE[?ff] // off and Off in particular are what we're looking for
+		{
+			!MODULE:HAS[@IDENTIFIER[ModuleBdbBoiloff]] {}	
+		}	
+	}
+	
+	// Remove reference to boiloff module from some other switches.
+	// Can still switch tank color for different mass options.
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[meshSwitchColor]] 
+	{
+		@SUBTYPE[Orange]
+		{
+			!MODULE:HAS[@IDENTIFIER[ModuleBdbBoiloff]] {}	
+		}	
+	}
+	
+	
+	// add CryoTanks boiloff module
+	MODULE
+	{
+		name =  ModuleCryoTank
+		CoolingEnabled = False
+		
+		BOILOFFCONFIG
+		{
+			FuelName = LqdHydrogen
+			// in % per hr
+			BoiloffRate = 0.05
+			CoolingCost = 0.05
+		}
+		
+		BOILOFFCONFIG
+		{
+			FuelName = LqdMethane
+			// in % per hr
+			BoiloffRate = 0.005
+			CoolingCost = 0.02
+		}
+	}
+	
+
+}


### PR DESCRIPTION
Replaces BDB boiloff with CryoTanks boiloff when both are installed. Because some players may not want to deal with two very different boiloff mechanics in the same playthrough. This is an optional patch for the Extras folder.

I have tested this and it works fine for me, but additional testing is of course always welcome. 