### PR TITLE
Update USI-LS.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/USI-LS/USI-LS.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/USI-LS/USI-LS.cfg
@@ -97,24 +97,88 @@
 		@amount += 480
 		@maxAmount += 480
 	}
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Recycler
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		CrewCapacity = 2
+		RecyclePercent = 0.50
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.25
+		}
+	}	
 }
 
 //-------------------------- Apollo
 
-@PART[bluedog_Apollo_Block2_ServiceModule]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_ServiceModule|bluedog_Apollo_Block2_SM]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
 {
-	@cost += 1875 // supplies * $2.5
+//	@cost += 1875 // supplies * $2.5
+	@mass -= 0.25
+	@description ^= :(.)$:$0\n<#14B437>Has supplies to support 3 crew for up to 10 days with 50% efficiency recycler.</color>:
 	RESOURCE
 	{
 		name = Supplies
-		amount = 750
+		amount = 650
 		maxAmount = 750
+	}
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Recycler
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		CrewCapacity = 3
+		RecyclePercent = 0.50
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.15
+		}
 	}
 }
 
 @PART[bluedog_Apollo_Block3_MissionModule]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
 {
-	@cost += 1875 // supplies * $2.5
+//	@cost += 1875 // supplies * $2.5
 	%MODULE[USI_SwapController]	{}
 	MODULE
 	{
@@ -153,9 +217,9 @@
 	}
 }
 
-@PART[bluedog_Apollo_Block4_MissionModule]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
+@PART[bluedog_Apollo_Block4_MissionModule|bluedog_spacelab_europeanModule]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
 {
-	@cost += 3645 // supplies * $2.5
+//	@cost += 3645 // supplies * $2.5
 	// Increased life support supply capacity over block III mission module
 
 	%MODULE[USI_SwapController]	{}
@@ -195,14 +259,16 @@
 	}
 }
 
-@PART[bluedog_LEM_Ascent_Cockpit]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
+@PART[bluedog_LEM_Ascent_Cockpit|bluedog_LM_Ascent_Cockpit]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
 {
-	@cost += 812 // Supplies *$2.5
-	@mass -= 0.125
+	@description ^= :(.)$:$0\n<#14B437>Has supplies to support 2 crew for 48 hours.</color>:
+	
+//	@cost += 812 // Supplies *$2.5
+	@mass -= 0.173
 	RESOURCE
 	{
 		name = Supplies
-		amount = 125
+		amount = 173
 		maxAmount = 325
 	}
 }
@@ -243,7 +309,7 @@
 		UseSpecialistBonus = false
 	}
 
-	MODULE:NEEDS[USILifeSupport]
+	MODULE
 	{
 		name = USILS_LifeSupportRecyclerSwapOption
 		ConverterName = Recycler
@@ -259,7 +325,7 @@
 			Ratio = 0.85
 		}	
 	}		
-	MODULE:NEEDS[USILifeSupport]
+	MODULE
 	{
 		name = USILS_HabitationSwapOption
 		ConverterName = Habitat
@@ -295,7 +361,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.00001
+			Ratio = 0.000001
 		}
 	}
 }
@@ -331,7 +397,7 @@
 		UseSpecialistBonus = false
 	}
 
-	MODULE:NEEDS[USILifeSupport]
+	MODULE
 	{
 		name = USILS_LifeSupportRecyclerSwapOption
 		ConverterName = Recycler
@@ -347,7 +413,7 @@
 			Ratio = 0.85
 		}	
 	}		
-	MODULE:NEEDS[USILifeSupport]
+	MODULE
 	{
 		name = USILS_HabitationSwapOption
 		ConverterName = Habitat
@@ -383,7 +449,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.00001
+			Ratio = 0.000001
 		}
 	}
 }
@@ -535,10 +601,12 @@
 	}
 }
 
+
+//----------------- Skylab ------------------------------
 // Enough Life Support Supplies to Allow 6 kerbals to survive in orbit for 3 months as per Manual II Mission Profile when used with recycler in the OWS
-@PART[bluedog_Spacelab_Adapter|bluedog_Skylab_Airlock]:NEEDS[USILifeSupport]:AFTER[Bluedog_DB]
+@PART[bluedog_Spacelab_Adapter|bluedog_Skylab_airlockModule]:NEEDS[USILifeSupport]:AFTER[Bluedog_DB]
 {
-	@cost += 3750 // supplies * $2.5
+//	@cost += 3750 // supplies * $2.5
 	RESOURCE
 	{
 		name = Supplies
@@ -553,11 +621,138 @@
 	}
 }
 
+//Skylab Multiple Docking Adapter
+@PART[bluedog_Skylab_multipleDockingAdapter]:NEEDS[USILifeSupport]:AFTER[Bluedog_DB]
+{
+//	@cost += 3750 // supplies * $2.5
+	RESOURCE
+	{
+		name = Supplies
+		amount = 500
+		maxAmount = 500
+	}
+	%MODULE[USI_SwapController]	{}
+	
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
+		BaseKerbalMonths = 6
+		CrewCapacity = 3
+		BaseHabMultiplier = 0.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.095
+		}
+	}
+}
+
+//Spacelab Adapter Module
+//smilar to Airlock module, but with increase space for habitation equipment
+@PART[bluedog_spacelab_forwardAdapter]:NEEDS[USILifeSupport]:AFTER[Bluedog_DB]
+{
+//	@cost += 3750 // supplies * $2.5
+	RESOURCE
+	{
+		name = Supplies
+		amount = 500
+		maxAmount = 1500
+	}
+	%MODULE[USI_SwapController]	{}
+	
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
+		BaseKerbalMonths = 12
+		CrewCapacity = 3
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.095
+		}
+	}
+}
+
+//Skylab EOSS Aft MDA
+@PART[bluedog_Skylab_EOSS_aftMDA]:NEEDS[USILifeSupport]:AFTER[Bluedog_DB]
+{
+//	@cost += 3750 // supplies * $2.5
+	RESOURCE
+	{
+		name = Supplies
+		amount = 500
+		maxAmount = 1500
+	}
+	%MODULE[USI_SwapController]	{}
+	
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
+		BaseKerbalMonths = 6
+		CrewCapacity = 3
+		BaseHabMultiplier = 0.24
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.325
+		}
+	}
+}
+
 // Adds habitation module to Skylab Orbital workshop
-@PART[bluedog_Skylab_OWS|bluedog_Skylab_OWS_Wet]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
+@PART[bluedog_Skylab_Workshop|bluedog_Skylab_OWS|bluedog_Skylab_OWS_Wet|bluedog_Skylab_WetWorkshop]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
 {
 	//CrewCapacity = 6
-	@cost += 8188 // Supplies * $2.5 + Machinery * $15.8
+//	@cost += 8188 // Supplies * $2.5 + Machinery * $15.8
 	@RESOURCE[ElectricCharge]
 	{
 		@amount += 6700
@@ -567,7 +762,7 @@
 	{
 		name = Supplies
 		amount = 500
-		maxAmount = 1000
+		maxAmount = 4000
 	}
 	RESOURCE
 	{
@@ -575,7 +770,7 @@
 		amount = 0
 		maxAmount = 360
 	}
-	MODULE:NEEDS[USILifeSupport]
+	MODULE
 	{
 		name = USI_SwapController 
 		ResourceCosts = Machinery,150,ElectricCharge,135
@@ -589,7 +784,7 @@
 	MODULE
 	{
 		name = USI_Converter
-		UseSpecialistBonus = false
+		UseSpecialistBonus = true
 	}
 
 	MODULE
@@ -643,32 +838,32 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.00001
+			Ratio = 0.000001
 		}
 	}
 }
 
 // Adds habitation to saturn planetary flyby module
-@PART[bluedog_Saturn_VFB_MissionModule]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
+@PART[bluedog_Saturn_VFB_MissionModule|bluedog_Skylab_VFB_ESM]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
 {
-	@cost += 4495 // Supplies *$2.5 + Feritilizer*$2 + Machinery * $15.8
+//	@cost += 4495 // Supplies *$2.5 + Feritilizer*$2 + Machinery * $15.8
 	RESOURCE
 	{
 		name = Supplies
 		amount = 250
-		maxAmount = 250
+		maxAmount = 2500
 	}
 	RESOURCE
 	{
 		name = Mulch
 		amount = 0
-		maxAmount = 25
+		maxAmount = 250
 	}
 	RESOURCE
 	{
 		name = Fertilizer
 		amount = 0
-		maxAmount = 750
+		maxAmount = 1500
 	}
 	RESOURCE
 	{
@@ -676,7 +871,7 @@
 		amount = 0
 		maxAmount = 150
 	}
-	MODULE:NEEDS[USILifeSupport]
+	MODULE
 	{
 		name = USI_SwapController 
 		ResourceCosts = Machinery,150,ElectricCharge,135
@@ -694,7 +889,7 @@
 	MODULE
 	{
 		name = USI_Converter
-		UseSpecialistBonus = false
+		UseSpecialistBonus = true
 	}
 	MODULE
 	{
@@ -709,7 +904,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 1
+			Ratio = 2.85
 		}
 	}
 	MODULE
@@ -724,7 +919,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.394
+			Ratio = 2.684
 		}
 	}
 	MODULE


### PR DESCRIPTION
Add new apollo and Skylab parts.
added Recyclers to Gemini and Apollo service modules to decrease the required supplies mass. With no customized USI values and no recyclers each kerbal uses 43.2 kg of supplies per day, a 50% efficiency recycler decreases it by half.