### PR TITLE
Fix surface attach nodes on Agena SPS

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Agena/bluedog_GATV_SPS.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Agena/bluedog_GATV_SPS.cfg
@@ -9,7 +9,7 @@ PART
 	}
 	rescaleFactor = 1
 
-	node_attach = 0.0, 0.0, -0.03759409, 0.0, 0.0, 1.0, 0, 0
+	node_attach = -0.03759409, 0.0, 0.0, -1.0, 0.0, 0.0, 0, 0
 
 	NODE
 	{

--- a/Gamedata/Bluedog_DB/Parts/Agena/bluedog_GATV_SPS_LFO.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Agena/bluedog_GATV_SPS_LFO.cfg
@@ -9,7 +9,7 @@ PART
 	}
 	rescaleFactor = 1
 
-	node_attach = 0.0, 0.0, -0.03759409, 0.0, 0.0, 1.0, 0, 0
+	node_attach = -0.03759409, 0.0, 0.0, -1.0, 0.0, 0, 0, 0
 
 	NODE
 	{

--- a/Gamedata/Bluedog_DB/Parts/Agena/bluedog_GATV_SPS_RCS.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Agena/bluedog_GATV_SPS_RCS.cfg
@@ -9,7 +9,7 @@ PART
 	}
 	rescaleFactor = 1
 
-	node_attach = 0.0, 0.0, -0.03759409, 0.0, 0.0, 1.0, 0, 0
+	node_attach = -0.03759409, 0.0, 0.0, -1.0, 0.0, 0.0, 0, 0
 
 	NODE
 	{


### PR DESCRIPTION
Doesn't break craft if they used the equipment rack stack nodes, the stock GATV craft file is unaffected. Fixes #1191 