### PR TITLE
Hypergolic BDB + RL10B3 and Minuteman M55

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/B9PS_Pafftek_Tank_Update.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/B9PS_Pafftek_Tank_Update.cfg
@@ -1,0 +1,54 @@
+B9_TANK_TYPE
+{
+	name = bdbAZ50NTO
+	tankMass = 0.000615    // Lighter weight to represent missing Insulation and attendants.
+	tankCost = 0.7
+	RESOURCE
+	{
+		name = Aerozine50
+		unitsPerVolume = 2.25 // 0.45 * 5
+	}
+	RESOURCE
+	{
+		name = NTO
+		unitsPerVolume = 2.75 // 0.55 * 5
+	}
+}
+B9_TANK_TYPE
+{
+	name = bdbAZ50NTOBAL
+	tankMass = 0.0003    // Lighter weight to represent missing Insulation and attendants.
+	tankCost = 0.95
+	RESOURCE
+	{
+		name = Aerozine50
+		unitsPerVolume = 2.25 // 0.45 * 5
+	}
+	RESOURCE
+	{
+		name = NTO
+		unitsPerVolume = 2.75 // 0.55 * 5
+	}
+}
+B9_TANK_TYPE
+{
+	name = bdbAZ50NTOSM
+	tankMass = 0.000625
+	tankCost = 0.71
+	RESOURCE
+	{
+		name = Aerozine50
+		unitsPerVolume = 2.25 // 0.45 * 5
+	}
+	RESOURCE
+	{
+		name = NTO
+		unitsPerVolume = 2.75 // 0.55 * 5
+	}
+	RESOURCE
+	{
+		name = MonoPropellant
+		unitsPerVolume = 0.1 
+	}
+}
+

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/BDB_HypergolicUpdate.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/BDB_HypergolicUpdate.cfg
@@ -1,0 +1,172 @@
+// Tag hypergolic parts :First so it carries over to +PART copies
+// Able & AbleStar & early Delta
+@PART[bluedog_Able_Engine]:First
+{
+	%bdbEngineType = bdbAZ50NTO
+}
+@PART[bluedog_Ablestar_Engine]:First
+{
+	%bdbEngineType = bdbAZ50NTO
+}
+@PART[bluedog_ThorAble_Tank,bluedog_DeltaB_Tank,bluedog_Vanguard_S2_Tank,bluedog_Ablestar_Tank]:First
+{
+	%bdbTankType = Hypergolic
+}
+
+// Agena
+@PART[bluedog_Agena_Tank*,bluedog_Agena_SOT_1p875m,bluedog_Agena_SOT_2p5m]:First
+{
+	%bdbTankType = HG_Monococue
+}
+
+@PART[bluedog_Agena_Engine_XLR81]:First
+{
+	%bdbEngineType = bdbAZ50NTO
+}
+@PART[bluedog_Agena_Engine_8096C]:First
+{
+ //as seperate from other Agena Engines for possible future fuel switch
+	%bdbEngineType = bdbAZ50NTO
+}
+// Apollo
+@PART[bluedog_Apollo_Block2_SPS,bluedog_LM_Ascent_Engine,bluedog_LM_Descent_Engine]:First
+{
+	%bdbEngineType = bdbAZ50NTO
+}
+@PART[bluedog_Apollo_Block2_SM,bluedog_Apollo_Block3_SM,bluedog_LM_Descent_Tanks,bluedog_LM_Ascent_Cockpit]:First
+{
+	%bdbTankType = Hypergolic
+}
+
+// Delta
+@PART[bluedog_AJ10_118F,bluedog_AJ10_118K,bluedog_AJ10_118X,bluedog_TR_201]:First
+{
+	%bdbEngineType = bdbAZ50NTO
+}
+@PART[bluedog_DeltaK_Stage,bluedog_DeltaP_Stage]:First
+{
+	%bdbTankType = Hypergolic
+}
+
+// Juno
+@PART[bluedog_Juno4_Engine_6K,bluedog_Juno4_Engine_45K]:First
+{
+	%bdbEngineType = bdbAZ50NTO
+}
+@PART[bluedog_Juno4_FuelTank_1,bluedog_Juno4_FuelTank_2]:First
+{
+	%bdbTankType = Hypergolic
+}
+
+
+// Titan
+@PART[bluedog_Titan_Transtage,bluedog_LR87_5,bluedog_LR87_11,bluedog_LR87_11_Single,bluedog_LR91_5,bluedog_LR91_11,bluedog_LR91_5_FourVernier,bluedog_LR91_11_FourVernier,bluedog_LR87_11_Vac]:First
+{
+	%bdbEngineType = bdbAZ50NTO
+}
+
+@PART[bluedog_Titan2_S1_Lower_Tank,bluedog_Titan2_S1_Upper_Tank,bluedog_Titan2_S2_Tank,bluedog_Titan3_S1_Stretched_Tank,bluedog_Titan4_S1_Lower_Tank,bluedog_Titan4_S2_Tank]:First
+{
+	%bdbTankType = Hypergolic
+}	
+
+// Add the fuel type to all tanks. Must be done at :AFTER[Bluedog_DB_1]   :HAS[!isMonococueTank = True]:HAS[!isBalloonTank = True]
+@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]:HAS[bdbTankType[!bdbBalloon]]]:AFTER[Bluedog_DB_1]
+{
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+	{
+		SUBTYPE
+		{
+			name = Hypergolic
+			tankType = bdbAZ50NTO
+			addedMass = #$../../tank_mass$
+			@addedMass *= -1
+			addedCost = #$../../tank_plus_fuel_cost$
+			@addedCost *= -1
+			percentFilled = #$../../fuelPctFill$
+		}		
+	}
+}
+
+@PART[bluedog*,Bluedog*]:HAS[#bdbTankType[HG_Monococue]]:BEFORE[Bluedog_DB_3]
+{
+
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+    {
+        %currentSubtype = LF/O Monococue
+        @SUBTYPE[LF/O]
+        {
+            @name =  LF/O Monococue
+            @tankType = bdbLFOX_Monococue
+        }
+    }
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+    {
+        %currentSubtype = Hypergolic Monococue
+        @SUBTYPE[Hypergolic]
+        {
+            @name = Hypergolic Monococue
+            @tankType = bdb_AZ50NTO_Monococue
+        }
+    }
+
+
+} 
+
+
+
+// Engine and tank setup
+@PART[bluedog*,Bluedog*]:HAS[#bdbEngineType[bdbAZ50NTO]]:AFTER[Bluedog_DB_2]
+{
+	// Changes the default fuel
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+	{
+		%currentSubtype = Hypergolic
+	}
+	
+	// Only need to change name. 2.25:2.75 is the same as 0.9:1.1
+	@MODULE[ModuleEngines*],*
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Aerozine50
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+		}
+	}
+	
+	// Not present in tanks, but some engines have fuel onboard
+	@RESOURCE[LiquidFuel]
+	{
+		@name = Aerozine50
+		@amount *= 5
+		@maxAmount *= 5
+	}
+	@RESOURCE[Oxidizer]
+	{
+		@name = NTO
+		@amount *= 5
+		@maxAmount *= 5
+	}
+}
+
+//This code sets default fuel type for Hypergolic tanks to Hypergolic (whatever subvariant)
+@PART[bluedog*,Bluedog*]:HAS[#bdbTankType[Hypergolic]]:BEFORE[zzzBluedog_DB_9]
+{
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+	{
+		%currentSubtype = Hypergolic
+	}
+}
+
+@PART[bluedog*,Bluedog*]:HAS[#bdbTankType[HG_Monococue]]:BEFORE[zzzBluedog_DB_9]
+{
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+	{
+		%currentSubtype = Hypergolic
+	}
+}
+// Cleanup for all bdbVariables is in base B9PartSwitchTanks file
+

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/Titan Fuel Switching.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/Titan Fuel Switching.cfg
@@ -1,0 +1,384 @@
+// Special setups
+
+// Reduce default fill for Titan
+// We want 83.16%, the resource bar only does 10% increments
+@PART[bluedog_Titan2*,bluedog_Titan3*,bluedog_Titan4*]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]]:AFTER[Bluedog_DB_2]
+{
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+	{
+		@SUBTYPE[Hypergolic]
+		{
+			%percentFilled = 80
+		}
+	}
+}
+
+
+@PART[bluedog_LR87_11_Single]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR87-AJ3-Single]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }
+    @SUBTYPE[LR87-AJ5K-Single]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }
+    @SUBTYPE[LR87-AJ11-K-Single]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+} 
+
+@PART[bluedog_LR87_5]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR87-AJ5K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+}
+
+@PART[bluedog_LR87_5]:HAS[#bdbEngineType[bdbAZ50NTO]]:AFTER[AJ9Upgrade]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR87-AJ9K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+}
+@PART[bluedog_LR87_11]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR87-AJ11K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+}  
+@PART[bluedog_LR87_11_Vac]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR87-AJ11-single-vac-k]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+}
+@PART[bluedog_LR87_11_Single]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR87-AJ3-Single]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }
+	@SUBTYPE[LR87-AJ5K-Single]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }
+	@SUBTYPE[LR87-AJ11-K-Single]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }	
+  }
+}
+@PART[bluedog_LR91_5]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR91-AJ5K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+}  
+@PART[bluedog_LR91_5]:HAS[#bdbEngineType[bdbAZ50NTO]]:AFTER[AJ9Upgrade]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR91-AJ9K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+}  
+@PART[bluedog_LR91_5_FourVernier]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR91-AJ5A4K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+}
+@PART[bluedog_LR91_11_FourVernier]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR91-AJ11-A4-K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+} 
+@PART[bluedog_LR91_11]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR91-AJ11-K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+        PROPELLANT
+        {
+            name = LiquidFuel
+            ratio = 0.9
+        }
+        PROPELLANT
+        {
+            name = Oxidizer
+            ratio = 1.1
+        }
+       }
+      }
+    }        
+  }
+}
+
+@PART[bluedog_Titan_Transtage]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[Transtage]
+    {
+		@tankType = bdbAZ50NTO
+    }
+    @SUBTYPE[Transtage-34D]
+    {
+		@tankType = bdbAZ50NTO
+    } 	
+  }
+}

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/Saturn MLV Series parts/Centaur_LR119.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/Saturn MLV Series parts/Centaur_LR119.cfg
@@ -1,0 +1,43 @@
+
+//An optional patch to add RL10-B-3 subtype to the RL-10
+
+@PART[bluedog_CentaurD_RL10]:FOR[Bluedog_DB]
+{
+	@tags ^= :$: RL10B3:
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+	{
+	 	SUBTYPE
+		{
+			name = RL10-B3
+			title = Inon-R-10B3 "Isorian"
+			descriptionSummary = The operational Isor engine. Used on Sarnus SIV and Inon C/E upper stages.
+			real_title = RL10-B-3
+			real_descriptionSummary = Uprated RL10-A-3 for Saturn as well as Centaur C/E.  Had USAF Designation of LR-119.  Never produced.
+			descriptionDetail = <b>Thrust:</b> 0.75 kN ASL / 16.5 kN Vac.\n<b>Isp:</b> 20 s ASL / 444 s Vac.
+			upgradeRequired = bluedog_RL100
+			addedCost = 100
+			defaultSubtypePriority = 1
+			transform = RL10_1
+
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+				}
+
+				DATA
+				{
+					maxThrust = 21
+					runningEffectName = running_engine
+					atmosphereCurve
+					{
+						key = 0 443
+						key = 1 15
+						key = 3 0.001
+					}
+				}
+			}
+		}
+	}
+}

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/Saturn MLV Series parts/MinutemanM55.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/Saturn MLV Series parts/MinutemanM55.cfg
@@ -1,0 +1,26 @@
++PART[bluedog_Scout_Algol_Radial]
+{
+	@name = bluedog_Saturn_M55_x
+	@cost = 1630
+	@MODEL
+	{
+		%scale = 1, 0.8, 1
+	}
+	@title = Velloxhominum-UT55R Solid Rocket Booster
+	@description = 0.9375m solid booster, with an integrated nosecone for radial attachment, derrived from the inline UT55I Engine.  Uses Algol Model as a stand in.
+	@real_title = M-55 Solid Rocket Motor (TU-122R) Uses Algol Model as a stand in.
+	@real_manufacturer = Morton Thiokol
+	@RESOURCE[SolidFuel]
+	{
+		@amount *= 1.2
+		@maxAmount *= 1.2
+	}	
+	
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]] {}
+
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 250
+
+	}
+}	

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Titan_AJ9/Titan_AJ9.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Titan_AJ9/Titan_AJ9.cfg
@@ -1,6 +1,6 @@
 //An optional patch to add AJ9 subtype to the lr87-AJ5 (closest visual analogue)
 
-@PART[bluedog_LR87_5]:FOR[Bluedog_DB]
+@PART[bluedog_LR87_5]:FOR[AJ9Upgrade]
 {
 	@tags ^= :$: AJ9:
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
@@ -35,11 +35,41 @@
 				}
 			}
 		}
+		SUBTYPE
+		{
+			name = LR87-AJ9K
+			title =	Prometheus LR8709-948-K "Phoebe" Liquid Engine
+			descriptionSummary = An undertaking by the BDB Special Orders Department to convert the Prometheus II engine back to the non toxic propellants originally used on Prometheus I. Sacrifices some thrust for a small Isp gain.  Powerful 1.875m engine for the Prometheus-III first stage. Used on the early Prometheus III-B & III-C.
+			real_title = LR87-AJ9
+			real_descriptionSummary = What if the LR87-AJ-9 had been converted from Hypergolics to non toxic Kerolox like the original Titan I?Engine for the Titan IIIB and IIIC. Replaced subsequently by the AJ11 for later Titan rockets of the 2x modex and latter.
+			descriptionDetail = <b>Thrust:</b> 470.2 kN ASL / 560 kN Vac.\n<b>Isp:</b> 252 s ASL / 300 s Vac.
+			defaultSubtypePriority = 3
+			addedCost = 220
+			upgradeRequired = bluedog_LR87AJ11 //ensures this is unlocked in the same node as Titan III parts
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+				}
+
+				DATA
+				{
+					maxThrust = 560
+					atmosphereCurve
+					{
+						key = 0 308
+						key = 1 260
+						key = 5 0.001
+					}
+				}
+			}
+		}		
 	}
 }
 //An optional patch to add AJ9 subtype to the lr91-AJ5 (closest visual analogue)
 
-@PART[bluedog_LR91_5]:FOR[Bluedog_DB]
+@PART[bluedog_LR91_5]:FOR[AJ9Upgrade]
 {
 	@tags ^= :$: AJ9:
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
@@ -47,10 +77,10 @@
 		SUBTYPE
 		{
 			name = LR91-AJ9
-			title =	Prometheus LR9107-948 "Phoebe" Liquid Engine
-			descriptionSummary = Powerful 1.875m engine for the Prometheus-III second stage. Used on the early Prometheus III-C, 23B and 24B.
+			title =	Prometheus LR9109-948 "Phoebe" Liquid Engine
+			descriptionSummary =   Powerful 1.875m engine for the Prometheus-III first stage. Used on the early Prometheus III-B & III-C.
 			real_title = LR91-AJ9
-			real_descriptionSummary = Engine for the Titan III-C, 23B and 33B. Replaced subsequently by the AJ11 for later Titan III rockets.
+			real_descriptionSummary = Engine for the Titan IIIB and IIIC. Replaced subsequently by the AJ11 for later Titan rockets of the 2x modex and latter.
 			descriptionDetail = <b>Thrust:</b> 89.52 kN ASL / 112.25 kN Vac.\n<b>Isp:</b> 172 s ASL / 316 s Vac.
 			defaultSubtypePriority = 3
 			addedCost = 110
@@ -69,6 +99,36 @@
 					{
 						key = 0 316
 						key = 1 172
+						key = 5 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = LR91-AJ9K
+			title =	Prometheus LR9109-948-K "Phoebe" Liquid Engine
+			descriptionSummary = An undertaking by the BDB Special Orders Department to convert the Prometheus II engines back to the non toxic propellants originally used on Prometheus I. Sacrifices some thrust for a small Isp gain. Used on the early Prometheus III-C, 23B and 24B.
+			real_title = LR91-AJ9
+			real_descriptionSummary = Engine for the Titan III-C, 23B and 33B. Replaced subsequently by the AJ11 for later Titan III rockets.
+			descriptionDetail = <b>Thrust:</b> 89.52 kN ASL / 109.33 kN Vac.\n<b>Isp:</b> 172 s ASL / 316 s Vac.
+			defaultSubtypePriority = 3
+			addedCost = 110
+			upgradeRequired = bluedog_LR87AJ11 //ensures this is unlocked in the same node as Titan III parts
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+					thrustVectorTransformName = thrustTransform
+				}
+				DATA
+				{
+					maxThrust = 106.33
+					atmosphereCurve
+					{
+						key = 0 332
+						key = 1 158
 						key = 5 0.001
 					}
 				}


### PR DESCRIPTION
Updates for BDB Extras for Hypergolic BDB  Patches built by Pappystein based on and initally supported by JSO

Altered Titan AJ9 file to mesh with rest of Titan Rocket parts and mesh with Hypergolic BDB

XLR-119 AKA RL10B-3 for Centaur C/E, S-IV (4 engine) and other fun

Minuteman M55 Solid.  Reuses Agol solid part as a new part (not a variant)