### PR TITLE
added USI options to VFB workshop

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/USI-LS/USI-LS.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/USI-LS/USI-LS.cfg
@@ -843,8 +843,8 @@
 	}
 }
 
-// Adds habitation to saturn planetary flyby module
-@PART[bluedog_Saturn_VFB_MissionModule|bluedog_Skylab_VFB_ESM]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
+// Adds habitation options to saturn planetary flyby module and workshop
+@PART[bluedog_Saturn_VFB_MissionModule|bluedog_Skylab_VFB_ESM|bluedog_Skylab_VFB_lightweightWetWorkshop]:NEEDS[USILifeSupport]:FOR[Bluedog_DB]
 {
 //	@cost += 4495 // Supplies *$2.5 + Feritilizer*$2 + Machinery * $15.8
 	RESOURCE


### PR DESCRIPTION
Added USI config options to VFB wet lab (same as in mission module).

Explanation: Long-term flyby with USI needs both home/hab timer and supplies recycling/production. The mission module only provides one of these so the workshop itself should be configurable to provide the other. Otherwise, the Kerbals will either go on strike due to homesickness or starve to death. :-)