### PR TITLE
waterfall patch update for rcs

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/WaterfallFX/ApolloRCS.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/WaterfallFX/ApolloRCS.cfg
@@ -1,5 +1,5 @@
 //rcsFX transforms
-@PART[bluedog_Apollo_RCS_2Way,bluedog_Apollo_RCS_45,bluedog_Apollo_RCS_45Tri,bluedog_Apollo_RCS_Quad,bluedog_Apollo_RCS_RadialQuad]:AFTER[Bluedog_DB]:NEEDS[Waterfall]
+@PART[bluedog_Apollo_RCS_2Way,bluedog_Apollo_RCS_45,bluedog_Apollo_RCS_45Tri,bluedog_Apollo_RCS_Quad,bluedog_Apollo_RCS_RadialQuad,bluedog_LM_Truck_RCS_3x,bluedog_LM_Truck_RCS_4x]:AFTER[Bluedog_DB]:NEEDS[Waterfall]
 {
 	// Removes the stock effect block, and replace it with one that has no particles
 	!EFFECTS {}

--- a/Gamedata/Bluedog_DB/Compatibility/WaterfallFX/Saturn_SkylabRCS.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/WaterfallFX/Saturn_SkylabRCS.cfg
@@ -1,4 +1,4 @@
-@PART[bluedog_Skylab_ACS,bluedog_GooLab_Module]:AFTER[Bluedog_DB]:NEEDS[Waterfall]
+@PART[bluedog_Skylab_ACS]:AFTER[Bluedog_DB]:NEEDS[Waterfall]
 {
 	// Removes the stock effect block, and replace it with one that has no particles
 	!EFFECTS {}
@@ -379,6 +379,61 @@
 			position = 0,0,0
 			rotation = -90, 0, 0
 			scale = 0.6, 1, 0.6
+		}
+	}
+}
+@PART[bluedog_GooLab_Module]:AFTER[Bluedog_DB]:NEEDS[Waterfall]
+{
+	// Removes the stock effect block, and replace it with one that has no particles
+	!EFFECTS {}
+	EFFECTS
+	{
+		rcs
+		{
+			AUDIO_MULTI
+			{
+				channel = Ship
+				transformName = rcsTransform
+				clip = sound_rocket_mini
+				volume = 0.0 0.0
+				volume = 0.1 0.0
+				volume = 0.5 0.025
+				volume = 1.0 0.2
+				pitch = 0.0 0.75
+				pitch = 1.0 1.5
+				loop = true
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = Skylab_RCS
+		// This links the effects to a given ModuleEngines
+
+		// List out all controllers we want available
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+			thrusterTransformName = rcsTransform
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = BDB_RCS_small_1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = rcsTransform
+			position = 0,0,0
+			rotation = 0, 0, 180
+			scale = 0.4, 0.7, 0.4
 		}
 	}
 }

--- a/Gamedata/Bluedog_DB/Compatibility/WaterfallFX/Saturn_SkylabRCS.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/WaterfallFX/Saturn_SkylabRCS.cfg
@@ -1,4 +1,4 @@
-@PART[bluedog_Skylab_ACS]:AFTER[Bluedog_DB]:NEEDS[Waterfall]
+@PART[bluedog_Skylab_ACS,bluedog_GooLab_Module]:AFTER[Bluedog_DB]:NEEDS[Waterfall]
 {
 	// Removes the stock effect block, and replace it with one that has no particles
 	!EFFECTS {}


### PR DESCRIPTION
goolab has it's own patch entry so it can just reference the rcsTransform transforms, since it lacks rcsFX transforms