### PR TITLE
Fix capitalization in WetLab module.

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S2_wetWorkshop.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S2_wetWorkshop.cfg
@@ -190,7 +190,7 @@ MODULE
 	{
 		name = ModuleBdbWetLab
 		labResource = ElectricCharge
-		crewCapacity = 12
+		CrewCapacity = 12
 	}
 
 	MODULE


### PR DESCRIPTION
This has been causing errors when using BDB with Kerbalism for Realism Overhaul/RP-1, and I'm not aware of changing it breaking anything else, so there's no reason I'm aware of to not just correct this.