### PR TITLE
Lrv tweaeks

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Descent_Tanks.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Descent_Tanks.cfg
@@ -152,6 +152,8 @@ RESOURCE
 			name = J Class
 			transform = J_Class
 			node =  lrv_Node
+            addedMass = -0.058
+            // CoMOffset = -0.0505, 0, 0.0505
 		}
 		SUBTYPE
 		{

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Q3_Storage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Q3_Storage.cfg
@@ -23,14 +23,14 @@ PART
 	real_description = Additional cargo capacity for the LM, useful for surface experiments and rover components. Attaches to Q3, on the back-right of the descent stage. 
 
 	attachRules = 0,1,0,0,0
-	mass = 0.002
+	mass = 0.088
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
 	angularDrag = 1
 	crashTolerance = 8
 	maxTemp = 1200 // = 3200
-	PhysicsSignificance = 1
+	// PhysicsSignificance = 1
 	bulkheadProfiles = srf
 
 	tags =  lm lem lander sina cargo storage capacity

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Q3_Storage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Q3_Storage.cfg
@@ -23,7 +23,7 @@ PART
 	real_description = Additional cargo capacity for the LM, useful for surface experiments and rover components. Attaches to Q3, on the back-right of the descent stage. 
 
 	attachRules = 0,1,0,0,0
-	mass = 0.088
+	mass = 0.09
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2


### PR DESCRIPTION
the mass removed from the J-class was completely arbitrary, and could be changed or reverted completely, it doesn't affect the balance of the COM, it just offsets the added mass a bit, and kinda makes sense as there's a big hole cut out of the side?