### PR TITLE
Final CoM balancing, and KJR compatability

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_Base.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_Base.cfg
@@ -77,7 +77,8 @@ PART
 	maximum_drag = 0.1
 	minimum_drag = 0.1
 	bulkheadProfiles = size0
-
+    PhysicsSignificance = -1
+    physicalSignificance = FULL
 	tags = LRV Lono rover drive car truck cck-rovers
 	techtag = lem
 

--- a/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_Hinge.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_Hinge.cfg
@@ -27,8 +27,6 @@
 		method = FIXED_JOINT
 	}
 
-	
-	
 	TechRequired = fieldScience
 	entryCost = 1000
 	cost = 50
@@ -58,7 +56,8 @@
 	maxTemp = 2000 // = 5000
 	bulkheadProfiles = size0
 	tags = LRV Lono rover drive car truck  robot actuator hinge cck-rovers
-	
+	PhysicsSignificance = -1
+    physicalSignificance = FULL
 	//stackSymmetry = 1
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_HingePlate_Aft.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_HingePlate_Aft.cfg
@@ -71,7 +71,8 @@
 	maxTemp = 2000 // = 5000
 	bulkheadProfiles = size0
 	tags = LRV Lono rover drive car truck  robot actuator hinge cck-rovers
-	
+	PhysicsSignificance = -1
+    physicalSignificance = FULL
 	//stackSymmetry = 1
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_HingePlate_Fore.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_HingePlate_Fore.cfg
@@ -71,7 +71,8 @@
 	maxTemp = 2000 // = 5000
 	bulkheadProfiles = size0
 	tags = LRV Lono rover drive car truck robot actuator hinge cck-rovers
-	
+	PhysicsSignificance = -1
+    physicalSignificance = FULL
 	//stackSymmetry = 1
 
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_LawnChair.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_LawnChair.cfg
@@ -46,6 +46,8 @@ PART
 	vesselType = Rover
 	// CrewCapacity = 0
 	bulkheadProfiles = srf
+    PhysicsSignificance = -1
+    physicalSignificance = FULL
 	tags = LRV Lono rover drive car truck chair control kerbal cck-rovers
 	
 	MODULE

--- a/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_Slider.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_Slider.cfg
@@ -27,14 +27,11 @@
 		method = FIXED_JOINT
 	}
 
-	
-	
 	TechRequired = fieldScience
 	entryCost = 1000
 	cost = 50
 	category = Robotics
 	subcategory = 0
-	
 	title =  Lono-MRV-SDM Deployment Hinge
 	manufacturer = Bluedog Design Bureau
 	description = Robotic slider for deploying the MRV from stowage on board a lander. 
@@ -58,7 +55,8 @@
 	maxTemp = 2000 // = 5000
 	bulkheadProfiles = size0
 	tags = LRV Lono rover drive car truck  robot actuator hinge cck-rovers
-	
+	PhysicsSignificance = -1
+    physicalSignificance = FULL
 	//stackSymmetry = 1
 
 MODULE

--- a/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_Wheel.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/LRV/bluedog_LRV_Wheel.cfg
@@ -46,6 +46,8 @@ PART
 	breakingForce = 50
 	breakingTorque = 50
 	bulkheadProfiles = srf
+    PhysicsSignificance = -1
+    physicalSignificance = FULL
 	tags = LRV Lono truck )car drive ground roll rover wheel cck-rovers
 	MODULE
 	{

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Q3_Storage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Q3_Storage.cfg
@@ -23,15 +23,16 @@ PART
 	real_description = Additional cargo capacity for the LM, useful for surface experiments and rover components. Attaches to Q3, on the back-right of the descent stage. 
 
 	attachRules = 0,1,0,1,0
-	mass = 0.15
-  CoMOffset = 0.132, 0.0, 0.00
+	mass = 0.1
+  //CoMOffset = 0.132, 0.0, 0.00
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
 	angularDrag = 1
 	crashTolerance = 8
 	maxTemp = 1200 // = 3200
-	// PhysicsSignificance = 1
+	PhysicsSignificance = -1
+        physicalSignificance = NONE
 	bulkheadProfiles = srf
 
 	tags =  lm lem lander sina cargo storage capacity

--- a/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Q3_Storage.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Apollo/bluedog_LM_Q3_Storage.cfg
@@ -24,7 +24,7 @@ PART
 
 	attachRules = 0,1,0,1,0
 	mass = 0.1
-  //CoMOffset = 0.132, 0.0, 0.00
+    // CoMOffset = -1.11, 0.0, 0.00
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -32,7 +32,7 @@ PART
 	crashTolerance = 8
 	maxTemp = 1200 // = 3200
 	PhysicsSignificance = -1
-        physicalSignificance = NONE
+    physicalSignificance = FULL
 	bulkheadProfiles = srf
 
 	tags =  lm lem lander sina cargo storage capacity
@@ -43,6 +43,29 @@ PART
 			InventorySlots = 7
 			packedVolumeLimit = 300
 	}
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = CoM
+		switcherDescription = Mass Offset
+		switcherDescriptionPlural = Mass Offsets
+        switchInFlight = False
 
+        SUBTYPE
+        {
+            name = Normal
+            CoMOffset = 0, 0, 0
+        }
+        SUBTYPE
+        {
+            name = Rover Counterweight
+            CoMOffset = -1.185, 0, 0
+        }
+        SUBTYPE
+        {
+            name = LM centre of thrust
+            CoMOffset = -1.35, 0, 0
+        }
+    }
 
 }


### PR DESCRIPTION
I couldn't help myself, and added a CoM switch to the cargo module with manual offsets, instead of it being physicisless. With the 7 lrv parts in it, and the rover counterweight offset selected, you can burn without SAS on and not have noticeable rotation. Also has an option to put the cargo module's CoM in-line with the LM's CoT, to simulate it being physicisless.