### PR TITLE
S1tweaks

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1C_Decoupler.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1C_Decoupler.cfg
@@ -65,5 +65,11 @@ MODULE
     isOmniDecoupler = false
     ejectionForce = 300
 }
-
+MODULE
+{
+    name = ModuleToggleCrossfeed
+    crossfeedStatus = false
+    toggleEditor = true
+    toggleFlight = true
+}
 }

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1C_EngineMount.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1C_EngineMount.cfg
@@ -384,21 +384,6 @@ childStageOffset = 0
 		
 		autoDeploy = False
 	}
-	MODULE
-	{
-		name = ModuleDecouple
-		isOmniDecoupler = false
-		ejectionForce = 300
-		explosiveNodeID = top
-		stagingToggleEnabledEditor = True
-		stagingEnabled = false
-	}
-	MODULE
-	{
-		name = ModuleToggleCrossfeed
-		crossfeedStatus = true
-		toggleEditor = false
-	}
 }
 
 

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1C_EngineMount.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1C_EngineMount.cfg
@@ -384,6 +384,21 @@ childStageOffset = 0
 		
 		autoDeploy = False
 	}
+	MODULE
+	{
+		name = ModuleDecouple
+		isOmniDecoupler = false
+		ejectionForce = 300
+		explosiveNodeID = top
+		stagingToggleEnabledEditor = True
+		stagingEnabled = false
+	}
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		crossfeedStatus = true
+		toggleEditor = false
+	}
 }
 
 

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1C_EngineMount.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1C_EngineMount.cfg
@@ -12,7 +12,7 @@ MODEL
 
 // --- node definitions ---
 
-node_stack_top = 0.0, 2.2808, 0.0, 0.0, 1.0, 0.0, 5
+node_stack_top = 0.0, 2.2958, 0.0, 0.0, 1.0, 0.0, 5
 
 	NODE
 	{
@@ -384,9 +384,6 @@ childStageOffset = 0
 		
 		autoDeploy = False
 	}
-	
-	
-
 }
 
 

--- a/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1D_BoosterSkirt.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/bluedog_Saturn_S1D_BoosterSkirt.cfg
@@ -12,7 +12,7 @@ MODEL
 
 // --- node definitions ---
 
-node_stack_top = 0.0, 2.2808, 0.0, 0.0, 1.0, 0.0, 5
+node_stack_top = 0.0, 2.2958, 0.0, 0.0, 1.0, 0.0, 5
 
 	NODE
 	{


### PR DESCRIPTION
Some minor tweaks to S1C skirts and decoupler.

the z-fighting in question:
![image](https://user-images.githubusercontent.com/2611674/179963547-fc40e403-1cb0-491f-a089-cb6b50ccf75c.png)

If a default-disabled decoupler in the S1C skirt itself isn't wanted, can revert that, but it would be nice to make recoverable engine stages with.