### PR TITLE
Update bluedog_Saturn_Engine_J2.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Saturn/Engines/bluedog_Saturn_Engine_J2.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Saturn/Engines/bluedog_Saturn_Engine_J2.cfg
@@ -15,7 +15,7 @@ node_stack_top = 0.0, 0.97549, 0.0, 0.0, 1.0, 0.0, 2
 node_stack_bottom = 0.0, -1.0667, 0.0, 0.0, -1.0, 0.0, 2
 
 // --- editor parameters ---
-TechRequired = heavierRocketry
+TechRequired = heavyRocketry
 entryCost = 21000
 cost = 5420
 category = Propulsion


### PR DESCRIPTION
This is for gameplay balance.  The J2 should be unlocked with the S-IVB.  That way you can fly the Saturn 1B before unlocking all the stuff for the Saturn V. 