### PR TITLE
Switchable scanners using B9PartSwitch

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/SCANsat/ResourceScanners.cfg
@@ -24,11 +24,7 @@
     }
 }
 
-@PART[Bluedog_Geiger,bluedog_Pioneer_GeigerTube]:FOR[zzzzBluedog_DB]:NEEDS[SCANsat]
-{
-		@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Uraninite and Monazite scanner.</color>:
-}
-
+//Magnetometers
 @PART[bluedog_foldingMag,bluedog_Pioneer6_Boom_Mag,bluedog_Helios_Magnetometer,bluedog_Pioneer_Magnetometer,bluedog_mariner10_magnetometer,bluedog_OGO_LongBoom_Hoop]:AFTER[Bluedog_DB]:NEEDS[SCANsat]
 {
 
@@ -114,8 +110,6 @@
 		@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Ore and Metallic Ore scanner.</color>:
 }
 
-
-
 // Scansat sensors
 //
 // Altimetry Lo = 1 (2^0)
@@ -130,7 +124,6 @@
 
 @PART[bluedog_IRspec]:AFTER[Bluedog_DB]:NEEDS[SCANsat]
 {
-
 	MODULE
 	{
 		name = SCANsat
@@ -213,17 +206,16 @@
 //Burke-2-RAD Radar Altimeter
 @PART[bluedog_Ranger_Block2_RadarAltimeter]:FOR[Bluedog_DB]:NEEDS[SCANsat]
 {
-
 	MODULE
 	{
-    name		= SCANsat
-    sensorType	= 1   //2^0
-    fov		= 2
-    min_alt		= 3000
-    max_alt		= 600000
-    best_alt	= 5000
-    scanName	= Radar Altimeter Scan
-    animationName = deploy
+		name		= SCANsat
+		sensorType	= 1	 //2^0
+		fov		= 2
+		min_alt		= 3000
+		max_alt		= 600000
+		best_alt	= 5000
+		scanName	= Radar Altimeter Scan
+		animationName = deploy
 		RESOURCE
 		{
 			name	= ElectricCharge
@@ -237,7 +229,7 @@
 		experimentType	= SCANsatAltimetryLoRes
 	}
 
-  !MODULE[DMModuleScienceAnimateGeneric] {} //Due to overlapping experiment
+	!MODULE[DMModuleScienceAnimateGeneric] {} //Due to overlapping experiment
 }
 @PART[bluedog_Ranger_Block2_RadarAltimeter]:FOR[zzzzBluedog_DB]:NEEDS[SCANsat]
 {
@@ -250,13 +242,13 @@
 
 	MODULE
 	{
-    		name		= SCANsat
-    		sensorType	= 1   //2^0
-    		fov		= 3
-    		min_alt		= 25000
-    		max_alt		= 600000
-    		best_alt	= 70000
-    		scanName	= LIDAR Altimetry Scan
+		name		= SCANsat
+		sensorType	= 1	 //2^0
+		fov		= 3
+		min_alt		= 25000
+		max_alt		= 600000
+		best_alt	= 70000
+		scanName	= LIDAR Altimetry Scan
 
 		RESOURCE
 		{
@@ -277,7 +269,7 @@
 	MODULE
 	{
 		name		= SCANsat
-		sensorType	= 16   //2^5 Anomaly detail
+		sensorType	= 16	 //2^5 Anomaly detail
 		fov		= 1
 		min_alt		= 0
 		max_alt		= 500000
@@ -470,7 +462,7 @@
 
 @PART[bluedog_Keyhole_Camera_KH1,bluedog_Keyhole_Camera_KH4,bluedog_Keyhole_Camera_KH4B]:FOR[Bluedog_DB]:NEEDS[SCANsat]
 {
-  MODULE
+	MODULE
 	{
 		name = SCANsat
 		sensorType = 4 //only visual low //2^2 + 2^4 Visual low res + anomaly basic
@@ -481,14 +473,14 @@
 		best_alt = 5000
 		scanName = Lo-Res Optical Surveillance
 		animationName = deploy
-    RESOURCE
+		RESOURCE
 		{
 			name = ElectricCharge
 			rate = 0.05
 		}
 	}
 
-  MODULE
+	MODULE
 	{
 		name = SCANexperiment
 		experimentType	= SCANsatVisual
@@ -497,16 +489,16 @@
 
 @PART[bluedog_MOL_Camera,bluedog_Keyhole_Camera_KH7,bluedog_Keyhole_Camera_KH8]:FOR[zzzzBluedog_DB]:NEEDS[SCANsat]//AFTER zzzBluedog_DB so as not to interfere with realnames patches which might change the description
 {
-  @description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Lo-Res Visual scanner. Requires sunlight to function.</color>:
+	@description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Lo-Res Visual scanner. Requires sunlight to function.</color>:
 }
 
 
-@PART[bluedog_cameraLowTech,bluedog_cameraMidTech,bluedog_cameraHighTech,bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem,bluedog_LunarOrbiter_Camera,bluedog_Mariner3_TV_Camera,bluedog_Mariner3_TV_Camera_UV]:AFTER[Bluedog_DB]:NEEDS[SCANsat]
+@PART[bluedog_cameraLowTech,bluedog_cameraMidTech,bluedog_cameraHighTech,bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem,bluedog_LunarOrbiter_Camera,bluedog_Mariner3_TV_Camera,bluedog_Mariner3_TV_Camera_UV]:FOR[Bluedog_DB]:NEEDS[SCANsat]
 {
-  MODULE
+	MODULE
 	{
 		name = SCANsat
-		sensorType = 4 //only visual low //20   //2^2 + 2^4 Visual low res + anomaly basic
+		sensorType = 4 //only visual low //20	 //2^2 + 2^4 Visual low res + anomaly basic
 		fov = 1.5
 		requireLight = True
 		min_alt = 5000
@@ -514,26 +506,205 @@
 		best_alt = 5000
 		scanName = Lo-Res Orbital Photography
 		animationName = deploy
-    RESOURCE
+		
+		RESOURCE
 		{
 			name = ElectricCharge
 			rate = 0.1
 		}
 	}
-
-  MODULE
+	MODULE
 	{
 		name = SCANexperiment
 		experimentType	= SCANsatVisual
 	}
+	
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		switcherDescription = Scanner Config
+		switcherDescriptionPlural = Scanner Configs
+        switchInFlight = False
+		moduleID = ScanSwitch
+
+		SUBTYPE
+		{
+			name = None
+			title = None
+			descriptionSummary = No frills.
+			descriptionDetail = Simplest option. Not useful for mapping, only for scientific experiments.
+			defaultSubtypePriority = 0
+			addedMass = 0.0
+			addedCost = 0
+			primaryColor = grey
+			secondaryColor = clear
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				moduleActive = False
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANexperiment
+				}
+				
+				moduleActive = False
+			}
+		}
+		SUBTYPE //VisualLoRes
+		{
+			name = Low-res Visual
+			title = Low-res Visual
+			descriptionSummary = Basic scanner 
+			descriptionDetail = Basic visual scanner. No spectral filters, only simple optics are used in this configuration.
+			defaultSubtypePriority = 1
+			addedMass = 0.0
+			addedCost = 0
+			primaryColor = white
+			secondaryColor = white
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				DATA
+				{
+					sensorType = 4 //only visual low //20	 //2^2 + 2^4 Visual low res + anomaly basic
+					fov = 1.5
+					requireLight = True
+					min_alt = 5000
+					max_alt = 500000
+					best_alt = 5000
+					scanName = Lo-Res Orbital Photography
+				}
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANexperiment
+				}
+				DATA
+				{
+					experimentType	= SCANsatVisual
+				}
+			}
+		}
+		SUBTYPE //Biome
+		{
+			name = Biome
+			title = Biome
+			descriptionSummary = Biome scanner 
+			descriptionDetail = Improved optics allowed for this camera to identify different biomes on the planetary surface.
+			defaultSubtypePriority = 0
+			addedMass = 0.0
+			addedCost = 2500
+			primaryColor = AcidGreen
+			secondaryColor = Cyan
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				DATA
+				{
+					sensorType = 12 //2^2 + 2^3, Visual low Res + Biome
+					fov = 1.25
+					requireLight = True
+					min_alt = 20000
+					max_alt = 300000
+					best_alt = 25000
+					scanName = Biome Orbital Photography
+					
+					RESOURCE
+					{
+						//ResourceName = ElectricCharge
+						rate = 0.15
+					}
+				}
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANexperiment
+				}
+				DATA
+				{
+					experimentType	= SCANsatBiomeAnomaly
+				}
+			}
+		}
+		SUBTYPE //Resource
+		{
+			name = ResourceLoRes
+			title = ResourceLoRes
+			descriptionSummary = Resoure scanner 
+			descriptionDetail = Using advanced, and expensive spectral filters allow for this camera to identify specific minerals in the planetary surface. 
+			defaultSubtypePriority = 0
+			addedMass = 0.0
+			addedCost = 9500
+			primaryColor = Magenta
+			secondaryColor = Apricot
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				DATA
+				{
+					sensorType = 132 //2^2 + 2^7, Visual low Res + Resouce Low Res
+					fov = 0.25
+					requireLight = True
+					min_alt = 20000
+					max_alt = 150000
+					best_alt = 25000
+					scanName = Lo-Res & Resource Mapping
+					
+					RESOURCE
+					{
+						//ResourceName = ElectricCharge
+						rate = 0.25
+					}
+				}
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANexperiment
+				}
+				DATA
+				{
+					experimentType	= SCANsatResources
+				}
+			}
+		} //end of SUBTYPE
+	}//end of B9PartSwitch
 }
 
 @PART[bluedog_mariner10_cameraStandalone,bluedog_mariner10_camera,bluedog_Pioneer_OrbiterScanner]:AFTER[Bluedog_DB]:NEEDS[SCANsat]
 {
-  MODULE
+	MODULE
 	{
 		name = SCANsat
-		sensorType = 4 //only visual low //20   //2^2 + 2^4 Visual low res + anomaly basic
+		sensorType = 4 //only visual low //20	 //2^2 + 2^4 Visual low res + anomaly basic
 		fov = 2
 		requireLight = True
 		min_alt = 5000
@@ -541,23 +712,202 @@
 		best_alt = 5000
 		scanName = Lo-Res Orbital Photography
 
-    		RESOURCE
+				RESOURCE
 		{
 			name = ElectricCharge
 			rate = 0.125
 		}
 	}
 
-  MODULE
+	MODULE
 	{
 		name = SCANexperiment
 		experimentType	= SCANsatVisual
 	}
+	
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		switcherDescription = Scanner Config
+		switcherDescriptionPlural = Scanner Configs
+        switchInFlight = False
+		moduleID = ScanSwitch
+
+		SUBTYPE
+		{
+			name = None
+			title = None
+			descriptionSummary = No frills.
+			descriptionDetail = Simplest option. Not useful for mapping, only for scientific experiments.
+			defaultSubtypePriority = 0
+			addedMass = 0.0
+			addedCost = 0
+			primaryColor = grey
+			secondaryColor = clear
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				moduleActive = False
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANexperiment
+				}
+				
+				moduleActive = False
+			}
+		}
+		SUBTYPE //VisualLoRes
+		{
+			name = Low-res Visual
+			title = Low-res Visual
+			descriptionSummary = Basic scanner 
+			descriptionDetail = Basic visual scanner. No spectral filters, only simple optics are used in this configuration.
+			defaultSubtypePriority = 1
+			addedMass = 0.0
+			addedCost = 0
+			primaryColor = white
+			secondaryColor = black
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				DATA
+				{
+					sensorType = 4 //only visual low //20	 //2^2 + 2^4 Visual low res + anomaly basic
+					fov = 2
+					requireLight = True
+					min_alt = 5000
+					max_alt = 500000
+					best_alt = 5000
+					scanName = Lo-Res Orbital Photography
+				}
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANexperiment
+				}
+				DATA
+				{
+					experimentType	= SCANsatVisual
+				}
+			}
+		}
+		SUBTYPE //Biome
+		{
+			name = Biome
+			title = Biome
+			descriptionSummary = Biome scanner 
+			descriptionDetail = Improved optics allowed for this camera to identify different biomes on the planetary surface.
+			defaultSubtypePriority = 0
+			addedMass = 0.0
+			addedCost = 2500
+			primaryColor = AcidGreen
+			secondaryColor = AquaBlue
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				DATA
+				{
+					sensorType = 12 //2^2 + 2^3, Visual low Res + Biome
+					fov = 1.25
+					requireLight = True
+					min_alt = 2000
+					max_alt = 450000
+					best_alt = 5000
+					scanName = Biome Orbital Photography
+					
+					RESOURCE
+					{
+						//ResourceName = ElectricCharge
+						rate = 0.175
+					}
+				}
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANexperiment
+				}
+				DATA
+				{
+					experimentType	= SCANsatBiomeAnomaly
+				}
+			}
+		}
+		SUBTYPE //Resource
+		{
+			name = ResourceLoRes
+			title = ResourceLoRes
+			descriptionSummary = Resoure scanner 
+			descriptionDetail = Using advanced, and expensive spectral filters allow for this camera to identify specific minerals in the planetary surface. 
+			defaultSubtypePriority = 0
+			addedMass = 0.0
+			addedCost = 9500
+			primaryColor = Magenta
+			secondaryColor = Apricot
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				DATA
+				{
+					sensorType = 132 //2^2 + 2^7, Visual low Res + Resouce Low Res
+					fov = 0.5
+					requireLight = True
+					min_alt = 5000
+					max_alt = 320000
+					best_alt = 25000
+					scanName = Lo-Res Resource Mapping
+					
+					RESOURCE
+					{
+						//ResourceName = ElectricCharge
+						rate = 0.25
+					}
+				}
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANexperiment
+				}
+				DATA
+				{
+					experimentType	= SCANsatResources
+				}
+			}
+		} //end of SUBTYPE
+	}//end of B9PartSwitch
 }
 
 @PART[bluedog_cameraLowTech,bluedog_cameraMidTech,bluedog_cameraHighTech,bluedog_Ranger_Block2_TVCamera,bluedog_Ranger_Block3_TVSystem,bluedog_LunarOrbiter_Camera,bluedog_mariner10_cameraStandalone,bluedog_mariner10_camera,bluedog_Pioneer_OrbiterScanner,bluedog_Mariner3_TV_Camera,bluedog_Mariner3_TV_Camera_UV]:FOR[zzzzBluedog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Lo-Res Visual scanner. Requires sunlight to function.</color>:
+	@description ^= :(.)$:$0\n<#7FD5FF> Has selectable SCANSAT scanner. Requires sunlight to function.</color>:
 }
 
 @PART[bluedog_Keyhole_Camera_KH7,bluedog_Keyhole_Camera_KH8]:FOR[Bluedog_DB]:NEEDS[SCANsat]
@@ -565,7 +915,7 @@
 	MODULE
 	{
 		name = SCANsat
-		sensorType = 64  //2^6+2^4
+		sensorType = 64	//2^6+2^4
 		fov = 3
 		requireLight = True
 		min_alt = 5000
@@ -580,7 +930,7 @@
 			rate = 0.1
 		}
 	}
-  MODULE
+	MODULE
 	{
 		name = SCANexperiment
 		experimentType	= SCANsatVisual
@@ -589,7 +939,7 @@
 
 @PART[bluedog_Keyhole_Camera_KH7,bluedog_Keyhole_Camera_KH8]:FOR[zzzzBluedog_DB]:NEEDS[SCANsat]//AFTER zzzBluedog_DB so as not to interfere with realnames patches which might change the description
 {
-  @description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Hi-Res Visual scanner. Requires sunlight to function.</color>:
+	@description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Hi-Res Visual scanner. Requires sunlight to function.</color>:
 }
 
 @PART[bluedog_Clementine_Sensors]:FOR[Bluedog_DB]:NEEDS[SCANsat]
@@ -611,7 +961,7 @@
 			rate = 0.15
 		}
 	}
-  MODULE
+	MODULE
 	{
 		name = SCANexperiment
 		experimentType	= SCANsatVisual
@@ -620,7 +970,7 @@
 
 @PART[bluedog_Clementine_Sensors]:FOR[zzzzBluedog_DB]:NEEDS[SCANsat]//AFTER zzzBluedog_DB so as not to interfere with realnames patches which might change the description
 {
-  @description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Hi-Res Visual and LIDAR altimetry scanners. Requires sunlight to function.</color>:
+	@description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Hi-Res Visual and LIDAR altimetry scanners. Requires sunlight to function.</color>:
 }
 
 @PART[bluedog_MOL_Camera,bluedog_Hexagon_Camera]:FOR[Bluedog_DB]:NEEDS[SCANsat]
@@ -628,7 +978,7 @@
 	MODULE
 	{
 		name = SCANsat
-		sensorType = 64  //2^6+2^5
+		sensorType = 64	//2^6+2^5
 		fov = 4
 		requireLight = True
 		min_alt = 5000
@@ -643,7 +993,7 @@
 			rate = 0.15
 		}
 	}
-  MODULE
+	MODULE
 	{
 		name = SCANexperiment
 		experimentType	= SCANsatVisual
@@ -652,16 +1002,15 @@
 //
 @PART[bluedog_MOL_Camera,bluedog_Hexagon_Camera]:FOR[zzzzBluedog_DB]:NEEDS[SCANsat]//AFTER zzzBluedog_DB so as not to interfere with realnames patches which might change the description
 {
-  @description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Hi-Res Visual scanner. Requires sunlight to function.</color>:
+	@description ^= :(.)$:$0\n<#7FD5FF> Has SCANSAT Hi-Res Visual scanner. Requires sunlight to function.</color>:
 }
 
 @PART[bluedog_Hexagon_MappingCamera]:AFTER[Bluedog_DB]:NEEDS[SCANsat]
 {
-
 	MODULE
 	{
 		name = SCANsat
-		sensorType = 24  //2^3 + 2^4
+		sensorType = 24	//2^3 + 2^4
 		fov = 5
 		min_alt = 5000
 		max_alt = 100000
@@ -695,7 +1044,7 @@
 	MODULE
 	{
 		name = SCANsat
-		sensorType	= 1   //2^0
+		sensorType	= 1	 //2^0
 		fov = 4
 		min_alt = 3000
 		max_alt = 400000
@@ -715,7 +1064,7 @@
 		experimentType = SCANsatAltimetryLoRes
 	}
 
-  !MODULE[ModuleScienceExperiment] {} //Due to overlapping experiment
+	!MODULE[ModuleScienceExperiment] {} //Due to overlapping experiment
 }
 
 @PART[bluedog_Skylab_radarAltimeter]:FOR[zzzzBluedog_DB]:NEEDS[SCANsat]
@@ -723,10 +1072,8 @@
 	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Low-Res Altimetery Scan.</color>:
 }
 
-
 @PART[bluedog_Skylab_multiSpectralScanner]:AFTER[Bluedog_DB]:NEEDS[SCANsat] //Multispectral Level 2
 {
-
 	MODULE
 	{
 		name = SCANsat
@@ -761,7 +1108,7 @@
 	MODULE
 	{
 		name = SCANsat
-		sensorType = 64  //2^6+2^4
+		sensorType = 64	//2^6+2^4
 		fov = 3
 		requireLight = True
 		min_alt = 5000
@@ -776,7 +1123,7 @@
 			rate = 0.175
 		}
 	}
-  	MODULE
+		MODULE
 	{
 		name = SCANexperiment
 		experimentType = SCANsatVisual
@@ -818,7 +1165,6 @@
 
 @PART[bluedog_Skylab_IRspec]:AFTER[Bluedog_DB]:NEEDS[SCANsat]
 {
-
 	MODULE
 	{
 		name = SCANsat
@@ -835,13 +1181,115 @@
 			rate = 0.075
 		}
 	}
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		switcherDescription = Scanner Config
+		switcherDescriptionPlural = Scanner Configs
+        switchInFlight = False
+		moduleID = ScanSwitch
+
+		SUBTYPE
+		{
+			name = None
+			title = None
+			descriptionSummary = No frills.
+			descriptionDetail = Simplest option. Not useful for mapping, only used for scientific experiments.
+			defaultSubtypePriority = 0
+			addedMass = 0.0
+			addedCost = -2000
+			primaryColor = Grey
+			secondaryColor = Grey
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				moduleActive = False
+			}
+		}
+		SUBTYPE //Biome
+		{
+			name = Biome
+			title = Biome
+			descriptionSummary = Biome scanner 
+			descriptionDetail = Improved optics allowed for this camera to identify different biomes on the planetary surface.
+			defaultSubtypePriority = 1
+			addedMass = 0.0
+			addedCost = 0
+			primaryColor = AcidGreen
+			secondaryColor = AquaBlue
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				DATA
+				{
+					sensorType = 8 //2^3, Biome
+					fov = 2
+					min_alt = 20000
+					max_alt = 400000
+					best_alt = 80000
+					scanName = Infrared Spectrometry Scan
+					requireLight = True
+					RESOURCE
+					{
+					//	name = ElectricCharge
+						rate = 0.075
+					}
+				}
+			}
+		}
+		SUBTYPE //Resource
+		{
+			name = ResourceLoRes
+			title = ResourceLoRes
+			descriptionSummary = Resoure scanner 
+			descriptionDetail = Using advanced, and expensive spectral filters allow for this camera to identify specific minerals in the planetary surface. 
+			defaultSubtypePriority = 0
+			addedMass = 0.0
+			addedCost = 7500
+			primaryColor = Magenta
+			secondaryColor = Apricot
+			
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = SCANsat
+				}
+
+				DATA
+				{
+					sensorType = 128 //2^7, Resouce Low Res
+					fov = 2
+					min_alt = 20000
+					max_alt = 320000
+					best_alt = 60000
+					scanName = Infrared Spectrometry Scan
+					requireLight = True
+					RESOURCE
+					{
+					//	name = ElectricCharge
+						rate = 0.15
+					}
+				}
+			}
+		} //end of SUBTYPE
+	}//end of B9PartSwitch
 }
 
 @PART[bluedog_Skylab_IRspec]:FOR[zzzzBluedog_DB]:NEEDS[SCANsat]
 {
-	@description ^= :(.)$:$0\n<#7FD5FF>Has SCANSAT Biome Scanner.</color>:
+	@description ^= :(.)$:$0\n<#7FD5FF>Can be configured either as a SCANSAT Biome or Resource Scanner.</color>:
 }
-
 
 //Apollo SIM bay
 @PART[bluedog_Apollo_SIMbay_mappingCamera]:FOR[BlueDog_DB]:NEEDS[SCANsat]
@@ -849,7 +1297,7 @@
 	MODULE
 	{
 		name = SCANsat
-		sensorType = 1   //2^0
+		sensorType = 1	 //2^0
 		fov = 3
 		min_alt = 3000
 		max_alt = 500000


### PR DESCRIPTION
I was building a Lunar Orbiter replica and though it would be nice to be able to switch between scanner types.
This patch adds a B9PartSwitch to some cameras with the following subtypes:

- None: removes SCANsat module, the part behaves as if the player did not have SCANsat installed.
- Low-res Visual: keeps the SCANsat parameters, no change in cost.
- Biome: changes the sensorType so it can be used as a visual low res and biome scanner, adds 2500 to the cost.
- Low res Resources: changes the sensorType so it can be used as a visual low res and resource scanner, adds 9500 to the cost.

Each subtype has its own color code, to make thinks clearer for the player.
![quackquack](https://user-images.githubusercontent.com/28099190/189919281-fa1f3993-4677-4cf5-8ae0-b4fed47d860c.png)
