### PR TITLE
Update bluedog_Gemini_EquipmentModule.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_EquipmentModule.cfg
+++ b/Gamedata/Bluedog_DB/Parts/Gemini/bluedog_Gemini_EquipmentModule.cfg
@@ -328,7 +328,7 @@ MODEL
 					OUTPUT_RESOURCE
 					{
 						ResourceName = Water
-						Ratio = 0.00055643
+						Ratio = 0.00055556
 						DumpExcess = True
 					}
 				}


### PR DESCRIPTION
Line 331, Current value produces water at a rate that exceeds input resources proportion. This can easily be seen when multiplying all the resources by 3600 to convert from u/sec to u/hour.