### PR TITLE
fix for B9/SimpleConstruction fatal error

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/ExtraplanetaryLaunchpads/ELCargo.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/ExtraplanetaryLaunchpads/ELCargo.cfg
@@ -70,7 +70,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,ExtraplanetaryLaunchpads,!SimpleConstruction]
 			addedCost = #$../../tank_plus_fuel_cost$
 			@addedCost *= -1
 		}
-		SUBTYPE
+		SUBTYPE:NEEDS[!SimpleConstruction]
 		{
 			name = ScrapMetal
 			tankType = bdbScrapMetal
@@ -79,7 +79,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,ExtraplanetaryLaunchpads,!SimpleConstruction]
 			addedCost = #$../../tank_plus_fuel_cost$
 			@addedCost *= -1
 		}
-        SUBTYPE
+    SUBTYPE:NEEDS[!SimpleConstruction]
 		{
 			name = MetalOre
 			tankType = bdbMetalOre


### PR DESCRIPTION
Did some intuitive debugging by reading through the contents of issue #1327 and trying a few edits to the patch in `Bluedog_DB\Compatibility\ExtraplanetaryLaunchpads\ELCargo.cfg` and think I was able to fix the problem by adding `:NEEDS[!SimpleConstruction]` to the subtype...not very familiar with KSP/ModuleManager config syntax so no idea if this is on the right track or not but thought I'd give it a go.