### PR TITLE
DO NOT TRY TO RESCALE IF RO IS PRESENT

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
@@ -60,9 +60,16 @@ BDBRESCALECONFIG
 	@systemScale = 6.4 // Adjustments are not valid beyond this scale
 }
 
-@BDBRESCALECONFIG:NEEDS[!SigmaDimensions,RealSolarSystem]:FOR[zzzBluedog_DB_0]
+//Do not adjust masses if RealismOverhaul is present
+@BDBRESCALECONFIG:NEEDS[!SigmaDimensions,!RealismOverhaul,RealSolarSystem]:FOR[zzzBluedog_DB_0]
 {
 	@systemScale = 6.4 // Adjustments are not valid beyond this scale
+}
+
+//DO NOT ADJUST MASSES IS REALISMOVERAL IS PRESENT!
+@BDBRESCALECONFIG:NEEDS[RealismOverhaul]:FOR[zzzBluedog_DB_0]
+{
+	@systemScale = 1.0
 }
 
 @BDBRESCALECONFIG:BEFORE[zzzBluedog_DB_1]


### PR DESCRIPTION
Make absolutely sure the SMURFF rescale patches do not apply if Realism Overhaul is present.
Resolves https://github.com/CobaltWolf/Bluedog-Design-Bureau/issues/1400