### PR TITLE
Update FreeIVA & CLS patches

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/ConnectedLivingSpace/CLSBluedogDB.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/ConnectedLivingSpace/CLSBluedogDB.cfg
@@ -372,6 +372,16 @@
 	}
 }
 
+// PMA that is passable
+@PART[bluedog_Skylab_PMA]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
 // Heatshields with hatches - part switch enables/disables passthrough
 @PART[bluedog_Gemini_Heatshield_2p5m|bluedog_Gemini_Heatshield_1p875m|bluedog_Gemini_Heatshield_1p5m]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]:LAST[ConnectedLivingSpace]
 {
@@ -498,5 +508,16 @@
 				}
 			}
 		}
+	}
+}
+
+// ----- Centaur
+
+@PART[bluedog_CentaurD_Avionics|bluedog_CentaurT_Avionics]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
 	}
 }

--- a/Gamedata/Bluedog_DB/Spaces/BDB_FreeIva.cfg
+++ b/Gamedata/Bluedog_DB/Spaces/BDB_FreeIva.cfg
@@ -124,3 +124,27 @@
 		doesNotBlockEVA = true
 	}
 }
+
+// ----- Centaur
+
+@PART[bluedog_CentaurD_Avionics|bluedog_CentaurT_Avionics]:NEEDS[FreeIva]
+{
+	MODULE
+	{
+		name = ModuleFreeIva
+		passThroughNodeA = top
+		passThroughNodeB = bottom
+	}
+}
+
+// ----- Skylab
+
+@PART[bluedog_Skylab_PMA]:NEEDS[FreeIva]
+{
+	MODULE
+	{
+		name = ModuleFreeIva
+		passThroughNodeA = top
+		passThroughNodeB = bottom
+	}
+}


### PR DESCRIPTION
- Added passthrough support for both FreeIVA and CLS for the Centaur avionics modules and the Skylab Presurised Mating Adapter