### PR TITLE
RSE compatibility

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-Liquid-Heavy.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-Liquid-Heavy.cfg
@@ -1,0 +1,56 @@
+//	M1
+@PART[bluedog_M1]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Heavy-Vacuum
+		volume = 1.36
+		pitch = 0.75
+	}
+}
+
+//	F1
+@PART[bluedog_Saturn_Engine_F1]:NEEDS[RocketSoundEnhancementDefault]
+{
+
+	RSE_PRESET
+	{
+		name = Liquid_Heavy-Lifter
+		volume = 1.14
+		pitch = 1.11
+	}
+}
+
+
+//	E-1
+@PART[bluedog_E1_engine]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Heavy-Sustainer
+		volume = 0.83
+		pitch = 1.00
+	}
+}
+
+// RS-68
+@PART[bluedog_DeltaIV_RS68]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Heavy-Sustainer
+		volume = 1.69
+		pitch = 1.25
+	}
+}
+
+// RD-180
+@PART[bluedog_AtlasV_RD180engine]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Heavy-Sustainer
+		volume = 1.20
+		pitch = 1.25
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-Liquid-Light.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-Liquid-Light.cfg
@@ -1,0 +1,120 @@
+//	RS30
+@PART[bluedog_RL20_SL,bluedog_RL20_Vac]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Vacuum
+		volume = 1.02
+		pitch = 1.0
+	}
+}
+
+//	Saturn Vernier
+@PART[bluedog_Saturn_S1D_Vernier]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Atmosphere
+		volume = 0.99
+		pitch = 1.15
+	}
+}
+
+//	Nuclear
+@PART[bluedog_SNTP*,bluedog_NERVA*,bluedog_smallNuclearEngine]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Vacuum
+		volume = 0.97
+		pitch = 1.00
+	}
+}
+
+//	Medium LH2
+@PART[bluedog_MB60,bluedog_MB60_deployable]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Vacuum
+		volume = 0.97
+		pitch = 1.00
+	}
+}
+
+//  LR-101
+@PART[bluedog_atlas_LR101,bluedog_Atlas_LR101_Inline,bluedog_Thor_LR101]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Atmosphere_1
+		volume = 0.85
+		pitch = 2.0
+	}
+}
+
+//  Small LH2
+@PART[bluedog_RS30,bluedog_CentaurD_RL1*]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Vacuum_1
+		volume = 0.87
+		pitch = 1.30
+	}
+}
+
+//  Early kerolox
+@PART[bluedog_Vanguard_GE405,bluedog_Vega_GE405H,bluedog_Redstone_A7*,bluedog_Redstone_QuadEngine,bluedog_Juno4_Engine_*,bluedog_X15_Engine]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Atmosphere_1
+		volume = 0.81
+		pitch = 2.40
+	}
+}
+
+//  Agena
+@PART[bluedog_Agena_Engine_XLR81,bluedog_Agena_Engine_8096C]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Atmosphere_1
+		volume = 0.79
+		pitch = 2.60
+	}
+}
+
+//  AJ-10s
+@PART[bluedog_Able_Engine,bluedog_Ablestar_Engine,bluedog_AJ10*,bluedog_Apollo_Block2_SPS,bluedog_Titan_Transtage]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Vacuum_1
+		volume = 0.85
+		pitch = 2.0
+	}
+}
+
+//  LMAE/LMDE
+@PART[bluedog_TR_201,bluedog_LM_Ascent_Engine,bluedog_LM_Descent_Engine]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Vacuum_1
+		volume = 0.85
+		pitch = 2.3
+	}
+}
+
+//  Micro
+@PART[bluedog_GATV_SPS,bluedog_Keyhole_OCV_KH7,bluedog_Minuteman_PSRE,bluedog_Apollo_RCS_Engine,bluedog_Apollo_RCS_EngineQuad,bluedog_LM_LunarFlyingVehicle,bluedog_Gemini_OAMSThruster,bluedog_Gemini_Lander_Engine,bluedog_Athena_OAM,bluedog_Peacekeeper_PostBoostVehicle,bluedog_HAPS*,bluedog_Minuteman_PSRE,bluedog_Burner2,bluedog_Hexagon_ServiceEngine,bluedog_RAE_VCPS,bluedog_LunarOrbiter_Propulsion,bluedog_Mariner_Midcourse_Engine,bluedog_mariner10_engine,bluedog_Pioneer_OrbiterPropulsionUnit,bluedog_Pioneer6_MidcourseEngine,bluedog_Ranger_Engine,bluedog_Ranger_Lander_Propulsion,bluedog_Surveyor_Vernier,bluedog_voyagerMarsLander_descentEngine,bluedog_Clementine_Engine,bluedog_C1engine]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Light-Vacuum_1
+		volume = 0.65
+		pitch = 2.6
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-Liquid-Medium.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-Liquid-Medium.cfg
@@ -1,0 +1,106 @@
+//	LR-87
+@PART[bluedog_LR87_*]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Medium-Lifter
+		volume = 0.91
+		pitch = 1.25
+	}
+}
+@PART[bluedog_LR87_*]:NEEDS[zzRocketSoundEnhancementDefault]
+{
+	@MODULE[RSE_Engines]
+	{
+		!Engage{}
+		Engage
+		{
+			SOUNDLAYER
+			{
+				name = Engage
+				audioClip = RocketSoundEnhancementDefault/Sounds/Engines/Liquid_Ignition-Bwoop
+				spread = 0.4
+			
+				volume = 0.75
+				pitch = 1.0
+			}
+		}
+	}
+}
+
+//	LR-91
+@PART[bluedog_LR91_*]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Medium-Vacuum
+		volume = 0.94
+		pitch = 1.00
+	}
+}
+
+//	LR-105
+@PART[bluedog_atlas_LR105engine]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Medium-Sustainer
+		volume = 0.87
+		pitch = 1.00
+	}
+}
+
+//	LR-89
+@PART[bluedog_atlas_LR89engine]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Medium-Lifter
+		volume = 0.83
+		pitch = 1.15
+	}
+}
+//H1
+@PART[bluedog_Saturn_Engine_H1*]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Medium-Lifter
+		volume = 0.83
+		pitch = 1.50
+	}
+}
+
+//	J2
+@PART[bluedog_Saturn_Engine_J*]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Medium-Vacuum
+		volume = 0.84
+		pitch = 1.25
+	}
+}
+
+
+//	LR-79
+@PART[bluedog_Thor_LR79]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Medium-Lifter
+		volume = 0.80
+		pitch = 1.25
+	}
+}
+
+//	XLR-129
+@PART[bluedog_XLR129]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = Liquid_Medium-Sustainer
+		volume = 0.78
+		pitch = 1.50
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-SRB-Heavy.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-SRB-Heavy.cfg
@@ -1,0 +1,32 @@
+//	S2-33 "Clydesdale" Solid Fuel Booster
+@PART[bluedog_Saturn_AJ260_Inline,bluedog_Saturn_AJ260_Radial]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = SRB_Heavy
+		volume = 1.52
+		pitch = 0.80
+	}
+}
+
+//	THK "Pollux" Solid Fuel Booster
+@PART[bluedog_UA120*,bluedog_SRMU*]:NEEDS[RocketSoundEnhancementDefault]
+{
+    RSE_PRESET
+	{
+		name = SRB_Heavy
+		volume = 1.01
+		pitch = 1.00
+	}
+}
+
+//	S1 SRB-KD25k "Kickback" Solid Fuel Booster
+@PART[bluedog_SOLTAN_SRB]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = SRB_Heavy
+		volume = 0.76
+		pitch = 1.2
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-SRB-Light.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-SRB-Light.cfg
@@ -1,0 +1,45 @@
+//	Castors
+@PART[bluedog_Castor2,bluedog_Castor4,bluedog_Castor4XL,bluedog_Pegasus_Orion50*,bluedog_Delta_GEM4*]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = SRB_Light_1
+		volume = 0.68
+		pitch = 1.00
+	}
+}
+
+//	Mini boosters
+@PART[bluedog_Sergeant_11x,bluedog_Sergeant_1x,bluedog_Sergeant_3x,bluedog_AIMP_Star13,bluedog_Explorer_Star17,bluedog_UpperSolids_Star24,bluedog_UpperSolids_Star37*,bluedog_UpperSolids_Star48BV,bluedog_UpperSolids_Altair,bluedog_UpperSolids_BE3,bluedog_IUS_Orbus6,bluedog_Pegasus_Orion38,bluedog_UpperSolids_Altair]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = SRB_Light_1
+		volume = 0.66
+		pitch = 1.30
+	}
+}
+
+//	Retros
+@PART[bluedog_atlas_retroMotor,bluedog_Mercury_RetroRocket,bluedog_Mercury_PosigradeRocket,bluedog_Corona_Retro,bluedog_Agena_Subsat_Hitchhiker,bluedog_Gemini_RetroMotor,bluedog_Saturn_AJ260_Sepratron,bluedog_Saturn_S4B_CentaurTruss,bluedog_Saturn_S4B_AARDVTruss,bluedog_Saturn_S1_Retro,bluedog_Saturn_S4B_Interstage,bluedog_Saturn_S4_AdapterTank,bluedog_Saturn_S2_Ullage,bluedog_Saturn_S4B_Ullage,bluedog_Saturn_S1C_EngineMount,bluedog_AtlasV_Star5F,bluedog_Titan1_SeparationBottle,bluedog_Titan2_S2_RetroMotor,bluedog_Titan2_S2_VernierMotor,bluedog_1875_NoseSep,bluedog_1875_RadialSep,bluedog_AtlasV_HLVnoseCone,bluedog_Hexagon_Mk8_Retro]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = SRB_Light_1
+		volume = 0.66
+		pitch = 1.20
+	}
+}
+
+//	Launch Escape Systems
+@PART[LaunchEscapeSystem]:NEEDS[RocketSoundEnhancementDefault]
+{
+	RSE_PRESET
+	{
+		name = SRB_Light_1
+		engineID = LES
+		volume = 0.50
+		pitch = 1.20
+	}
+}
+

--- a/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-SRB-Medium.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RSE/BDB-SRB-Medium.cfg
@@ -1,0 +1,32 @@
+//	BACC "Thumper" Solid Fuel Booster
+@PART[bluedog_Peacekeeper_Castor120,bluedog_Minotaur1_M55A1,bluedog_AtlasV_AJ60motor,bluedog_AtlasV_GEM6*]:NEEDS[RocketSoundEnhancementDefault]
+{
+    RSE_PRESET
+	{
+		name = SRB_Medium
+		volume = 0.70
+		pitch = 0.85
+	}
+}
+
+//	RT-10 "Hammer" Solid Fuel Booster
+@PART[bluedog_Minotaur1_SR19,bluedog_Peacekeeper_SR*,bluedog_Minuteman_SR73]:NEEDS[RocketSoundEnhancementDefault]
+{
+    RSE_PRESET
+	{
+		name = SRB_Medium
+		volume = 0.64
+		pitch = 1.00
+	}
+}
+
+//	RT-5 "Flea" Solid Fuel Booster
+@PART[bluedog_Athena_Castor3*,bluedog_IUS_Orbus21]:NEEDS[RocketSoundEnhancementDefault]
+{
+    RSE_PRESET
+	{
+		name = SRB_Medium
+		volume = 0.61
+		pitch = 1.15
+	}
+}

--- a/Gamedata/Bluedog_DB/Compatibility/RSE/RCS.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RSE/RCS.cfg
@@ -1,0 +1,123 @@
+//	Large RCS
+@PART[bluedog_Saturn_S4B_APS_200,bluedog_Saturn_S4B_APS_500,bluedog_Saturn_S4B_APS_550,bluedog_Skylab_TRS_propulsionKit,bluedog_Atlas2_RollControlSystem]:NEEDS[RocketSoundEnhancementDefault]
+{
+    MODULE
+	{
+		name = RSE_RCS
+		volume = 1.0
+		
+        SOUNDLAYER
+		{
+			name = Thrust
+			audioClip = RocketSoundEnhancementDefault/Sounds/RCS/RCS_Heavy
+			loop = true
+			spread = 0.25
+			
+			volume = 0.0 0.0
+			volume = 0.25 0.5
+			volume = 1.0 1.0
+			
+			pitch = 1.0
+		}
+    }
+}
+
+//	Medium RCS
+@PART[bluedog_GATV_SPS_RCS,bluedog_MOL_RCS,bluedog_MOL_RCS_Alt1,bluedog_MOL_RCS_Alt2,bluedog_MOL_RCS_Alt3,bluedog_GeminiFerry_RCS_45deg,bluedog_GeminiFerry_RCS,bluedog_Titan23G_ACS,bluedog_X15_NoseGear,bluedog_X15_Wing,bluedog_X15_DeltaWing]:NEEDS[RocketSoundEnhancementDefault]
+{
+    MODULE
+	{
+		name = RSE_RCS
+		volume = 1.0
+		
+        SOUNDLAYER
+		{
+			name = Thrust
+			audioClip = RocketSoundEnhancementDefault/Sounds/RCS/RCS_Medium
+			loop = true
+			spread = 0.25
+			
+			volume = 0.0 0.0
+			volume = 0.25 0.5
+			volume = 1.0 1.0
+			
+			pitch = 1.2
+		}
+		
+    }
+}
+
+//	Mini RCS
+@PART[bluedog_ThorAble_Tank,bluedog_DeltaB_Tank,bluedog_Agena_EngineShroud,bluedog_Agena_EquipmentRack,bluedog_ATDA_RCS,bluedog_Gemini_ArrowSM,bluedog_Gemini_EquipmentModule_Empty,bluedog_Gemini_EquipmentModule,bluedog_Gemini_LongFerrySM,bluedog_Gemini_LunarReconSM,bluedog_Gemini_ReentryRCS,bluedog_Gemini_RetroModule,bluedog_Shuguang_EquipmentModule,bluedog_Shuguang_RetroModule,bluedog_Gemini_Lander_SaddleTank,bluedog_Hexagon_LifeboatRCS,bluedog_Juno4_FuelTank_2,bluedog_Jupiter_Guidance,bluedog_Mercury_ParachuteRCS,bluedog_Mercury_Capsule,bluedog_Gemini_RotationRCS,bluedog_Gemini_TranslationRCS,bluedog_Sparta_ControlJets,bluedog_Redstone_AirVane,bluedog_Juno1_Guidance,bluedog_Skylab_VFB_entryProbe,bluedog_Ablestar_Tank,bluedog_DeltaE_Tank,bluedog_HOSS_EngineMount,bluedog_Titan3_CommercialPL*,bluedog_Vanguard_S2_Tank,bluedog_Vega_Tank1,bluedog_Vega_ThirdStage_Tank,bluedog_Centaur_ARCM,bluedog_CentaurV_EngineMount,bluedog_CentaurD_EngineMount,bluedog_Centaur_Kickstage]:NEEDS[RocketSoundEnhancementDefault]
+{
+    	MODULE
+	{
+		name = RSE_RCS
+		volume = 1.0
+		
+        		SOUNDLAYER
+		{
+			name = Thrust
+			audioClip = RocketSoundEnhancementDefault/Sounds/RCS/RCS_Light
+			loop = true
+			spread = 0.25
+			
+			volume = 0.0 0.0
+			volume = 0.25 0.5
+			volume = 1.0 1.0
+			
+			pitch = 1.2
+		}
+		
+    }
+}
+
+//	Small RCS
+@PART[bluedog_GATV_SPS_RCS,bluedog_Apollo_RCS_2Way,bluedog_Apollo_RCS_45,bluedog_Apollo_RCS_45Tri,bluedog_Apollo_RCS_Quad,bluedog_Apollo_RCS_RadialQuad,bluedog_LM_Truck_RCS_3x,bluedog_LM_Truck_RCS_4x,bluedog_Apollo_RCS_3Way,bluedog_Apollo_RCS_Double,bluedog_Apollo_RCS_Linear,bluedog_Apollo_RCS_PitchRoll,bluedog_Apollo_RCS_RadialUllage,bluedog_Apollo_RCS_Sideways,bluedog_Apollo_RCS_Ullage,bluedog_Apollo_RCS_2Way_45deg,bluedog_Apollo_RCS_Tri,bluedog_Hexagon_MainRCS,bluedog_Skylab_ACS,bluedog_MORL_resistojet_RCS,bluedog_Skylab_TRS_probeCore,bluedog_GooLab_Module,bluedog_Burner2,bluedog_IUS_Avionics,bluedog_TOS_Avionics,bluedog_Minotaur_GCA,bluedog_Titan_Transtage_RCS_*]:NEEDS[RocketSoundEnhancementDefault]
+{
+    MODULE
+	{
+		name = RSE_RCS
+		volume = 1.0
+		
+        SOUNDLAYER
+		{
+			name = Thrust
+			audioClip = RocketSoundEnhancementDefault/Sounds/RCS/RCS_Light
+			loop = true
+			spread = 0.25
+			
+			volume = 0.0 0.0
+			volume = 0.25 0.5
+			volume = 1.0 1.0
+			
+			pitch = 1.0
+		}
+		
+    }
+}
+
+//Probe RCS
+@PART[bluedog_AIMP_SolarPaddle,bluedog_Clementine_LowerRCS,bluedog_Clementine_UpperRCS,bluedog_RAE_RCS,bluedog_Helios_SunShade,bluedog_IDCSP_Probe,bluedog_Kepler_RCS,bluedog_LunarOrbiter_Propulsion,bluedog_Mariner3_Solar,bluedog_Mariner5_Solar,bluedog_Mariner5_Solar_Antenna,bluedog_mariner10_solar,bluedog_mariner10_highGainAntenna,bluedog_Nimbus_LateControlCore,bluedog_Nimbus_EarlyCommandAntenna,bluedog_OAO_balanceBoom,bluedog_OGO_RCS,bluedog_OSO_Arm,bluedog_OSO_Sail,bluedog_Pioneer_HGA,bluedog_Pioneer6_RCS,bluedog_probeRCSblock,bluedog_probeRCSblockE,bluedog_Ranger_Bus,bluedog_MarinerB_Bus,bluedog_ProbeRCS_*,bluedog_Surveyor_Leg,bluedog_SurveyorOrbiter_Solar,bluedog_Syncom,bluedog_TIROS,bluedog_POPPY2_RCS,bluedog_POPPY2_RCS_Antenna,bluedog_voyagerMarsOrbiter_SM,bluedog_voyagerMarsOrbiter_heatshield,bluedog_voyagerMarsLander_leg]:NEEDS[RocketSoundEnhancementDefault]
+{
+    	MODULE
+	{
+		name = RSE_RCS
+		volume = 1.0
+		
+        		SOUNDLAYER
+		{
+			name = Thrust
+			audioClip = RocketSoundEnhancementDefault/Sounds/RCS/RCS_Light
+			loop = true
+			spread = 0.25
+			
+			volume = 0.0 0.0
+			volume = 0.25 0.5
+			volume = 1.0 1.0
+			
+			pitch = 1.2
+		}
+		
+    }
+}

--- a/Gamedata/Bluedog_DB/Compatibility/RSE/SoundRemover.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RSE/SoundRemover.cfg
@@ -1,0 +1,51 @@
+//	Engines Sound Remover
+@PART[*]:HAS[@MODULE[RSE_Engines]]:FOR[zzzRocketSoundEnhancementDefault]:NEEDS[RocketSoundEnhancement]
+{
+	@EFFECTS,*
+	{
+		//	BDB Rockets
+		@running_engine{!AUDIO{}}
+		@running_engine2{!AUDIO{}}
+		@running_seaLevel{!AUDIO{}}
+		@running_solid{!AUDIO{}}
+		@running_booster{!AUDIO{}}
+		@running_sustainer{!AUDIO{}}
+		@running_vac{!AUDIO{}}
+		@runningRCS{!AUDIO_MULTI{}}
+		@runningfore{!AUDIO_MULTI_POOL{}}
+		@runningaft{!AUDIO_MULTI_POOL{}}
+		@engine_running{!AUDIO{}}
+		@running_regen{!AUDIO{}}
+		@running_vernier{!AUDIO{}}
+		@running_hydyne{!AUDIO{}}
+		@running_f1B{!AUDIO{}}
+		@running_augmented{!AUDIO{}}
+		@running_kerolox{!AUDIO{}}
+		@running_kerolox_vernier{!AUDIO{}}
+		@running_xlr11{!AUDIO{}}
+	}
+}
+
+//	RCS Sound Remover
+@PART[*]:HAS[@MODULE[RSE_RCS]]:FOR[zzzRocketSoundEnhancementDefault]:NEEDS[RocketSoundEnhancement]
+{
+	@EFFECTS
+	{
+		@running
+		{
+			!AUDIO{}
+			!AUDIO_MULTI_POOL{}
+		}
+		@rcs*
+		{
+			!AUDIO{}
+			!AUDIO_MULTI_POOL{}
+		}
+		@roll
+		{
+			!AUDIO{}
+			!AUDIO_MULTI_POOL{}
+		}
+	}
+}
+


### PR DESCRIPTION
Rocket Sound Enhancement configs for engines and RCS. Rover wheels coming soon. Rather basic, uses settings from default configuration with few alterations, but it should add it to every engine and RCS thruster in the mod.

Once Titan engines are stabilized, I'll update the configs if needed.