### PR TITLE
Extras Update of Hypergolic Patch

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/BDB_HypergolicUpdate.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/BDB_HypergolicUpdate.cfg
@@ -64,8 +64,8 @@
 }
 
 
-// Titan
-@PART[bluedog_Titan_Transtage,bluedog_LR87_5,bluedog_LR87_11,bluedog_LR87_11_Single,bluedog_LR91_5,bluedog_LR91_11,bluedog_LR91_5_FourVernier,bluedog_LR91_11_FourVernier,bluedog_LR87_11_Vac]:First
+// Titan old no longer modified parts bluedog_LR87,bluedog_LR87_11_Single,bluedog_LR91_5,bluedog_LR91_11,bluedog_LR91_5_FourVernier,bluedog_LR91_11_FourVernier,bluedog_LR87_11_Vac
+@PART[bluedog_Titan_Transtage]:First
 {
 	%bdbEngineType = bdbAZ50NTO
 }

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/Titan Fuel Switching.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/Titan Fuel Switching.cfg
@@ -14,359 +14,429 @@
 }
 
 
-@PART[bluedog_LR87_11_Single]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
+@PART[bluedog_LR87]:BEFORE[Bluedog_DB_8]   // Base Titan First stage engine and all variants
 {
-  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
-  {
-    @SUBTYPE[LR87-AJ3-Single]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }
-    @SUBTYPE[LR87-AJ5K-Single]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }
-    @SUBTYPE[LR87-AJ11-K-Single]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }        
-  }
-} 
 
-@PART[bluedog_LR87_5]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
-{
   @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
   {
-    @SUBTYPE[LR87-AJ5K]
+    @SUBTYPE[LR87-AJ5]
     {
       @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
       {
         @DATA{
         
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }        
-  }
-}
-
-@PART[bluedog_LR87_5]:HAS[#bdbEngineType[bdbAZ50NTO]]:AFTER[AJ9Upgrade]
-{
-  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
-  {
-    @SUBTYPE[LR87-AJ9K]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }        
-  }
-}
-@PART[bluedog_LR87_11]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
-{
-  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
-  {
-    @SUBTYPE[LR87-AJ11K]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }        
-  }
-}  
-@PART[bluedog_LR87_11_Vac]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
-{
-  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
-  {
-    @SUBTYPE[LR87-AJ11-single-vac-k]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }        
-  }
-}
-@PART[bluedog_LR87_11_Single]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
-{
-  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
-  {
-    @SUBTYPE[LR87-AJ3-Single]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = Aerozine50
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = NTO
+				%ratio = 1.1				
+			}
        }
       }
     }
-	@SUBTYPE[LR87-AJ5K-Single]
+    @SUBTYPE[LR87-AJ9]
     {
       @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
       {
         @DATA{
         
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }
-	@SUBTYPE[LR87-AJ11-K-Single]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = Aerozine50
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = NTO
+				%ratio = 1.1				
+			}
        }
       }
     }	
-  }
-}
-@PART[bluedog_LR91_5]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
-{
-  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
-  {
-    @SUBTYPE[LR91-AJ5K]
+    @SUBTYPE[LR87-AJ11-1]
+    {
+			%title = LR8711-600-G "Astreous"		
+			&descriptionDetail = <b>Thrust:</b> 494.7 kN ASL / 600.5 kN Vac.\n<b>Isp:</b> 250 s ASL / 302 s Vac.			
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+			#maxThrust = 600.5        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = Aerozine50
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = NTO
+				%ratio = 1.1				
+			}
+       }
+      }
+    }
+    @SUBTYPE[LR87-AJ11-2]
+    {
+			%title = LR8711-603-A "Astreous"	
+			%descriptionDetail = <b>Thrust:</b> 481.2 kN ASL / 603 kN Vac.\n<b>Isp:</b> 245 s ASL / 307 s Vac.
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+			#maxThrust = 603        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = Aerozine50
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = NTO
+				%ratio = 1.1				
+			}
+       }
+      }
+    }       
+    @SUBTYPE[LR87-AJ11A]
     {
       @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
       {
         @DATA{
         
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = Aerozine50
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = NTO
+				%ratio = 1.1				
+			}
        }
       }
-    }        
+    }       	
+  }
+}
+
+
+
+@PART[bluedog_LR87_Single]:BEFORE[Bluedog_DB_8]  //  Single bell LR87 for nonstandard uses
+{
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
+  {
+    @SUBTYPE[LR87-AJ5-Single]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = Aerozine50
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = NTO
+				%ratio = 1.1				
+			}
+       }
+      }
+    }
+	@SUBTYPE[LR87-AJ11-Single]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = Aerozine50
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = NTO
+				%ratio = 1.1				
+			}
+       }
+      }
+    }
+	@SUBTYPE[LR87-AJ11-single-vac]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = Aerozine50
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = NTO
+				%ratio = 1.1				
+			}
+       }
+      }
+    }
+
+
   }
 }  
-@PART[bluedog_LR91_5]:HAS[#bdbEngineType[bdbAZ50NTO]]:AFTER[AJ9Upgrade]
+@PART[bluedog_LR91]:BEFORE[Bluedog_DB_8]    //LR91-AJ-x for Titan 2nd Stage  Includes both Single and Quad Nerniers *sic* 
 {
+	@MODULE[ModuleEngines*],*
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Aerozine50
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+		}
+	}
   @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
   {
-    @SUBTYPE[LR91-AJ9K]
+    @SUBTYPE[AJ3]
     {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
+      @MODULE:HAS[@IDENTIFIER:HAS[#thrustVectorTransformName[thrustTransform]]]
       {
         @DATA{
         
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
        }
       }
-    }        
+      @MODULE:HAS[@IDENTIFIER:HAS[#engineID[vernier]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }	  
+    }
+	@SUBTYPE[AJ3SV]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#thrustVectorTransformName[thrustTransform]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }
+      @MODULE:HAS[@IDENTIFIER:HAS[#engineID[vernier]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }	  
+    }
+    @SUBTYPE[AJ5K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#thrustVectorTransformName[thrustTransform]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }
+      @MODULE:HAS[@IDENTIFIER:HAS[#engineID[vernier]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }	  
+    }
+	@SUBTYPE[AJ5QVK]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#thrustVectorTransformName[thrustTransform]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }
+      @MODULE:HAS[@IDENTIFIER:HAS[#engineID[vernier]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }	  
+    }   
+	@SUBTYPE[AJ11K]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#thrustVectorTransformName[thrustTransform]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }
+      @MODULE:HAS[@IDENTIFIER:HAS[#engineID[vernier]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }	  
+    }
+	@SUBTYPE[AJ11QVK]
+    {
+      @MODULE:HAS[@IDENTIFIER:HAS[#thrustVectorTransformName[thrustTransform]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }
+      @MODULE:HAS[@IDENTIFIER:HAS[#engineID[vernier]]]
+      {
+        @DATA{
+        
+			%PROPELLANT[LiquidFuel]
+			{
+				%name = LiquidFuel
+				%ratio = 0.9
+				%DrawGauge = True				
+			}
+			%PROPELLANT[Oxidizer]
+			{
+				%name = Oxidizer
+				%ratio = 1.1				
+			}
+       }
+      }	  
+    }	
+
   }
 }  
-@PART[bluedog_LR91_5_FourVernier]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
-{
-  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
-  {
-    @SUBTYPE[LR91-AJ5A4K]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }        
-  }
-}
-@PART[bluedog_LR91_11_FourVernier]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
-{
-  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
-  {
-    @SUBTYPE[LR91-AJ11-A4-K]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }        
-  }
-} 
-@PART[bluedog_LR91_11]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
-{
-  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
-  {
-    @SUBTYPE[LR91-AJ11-K]
-    {
-      @MODULE:HAS[@IDENTIFIER:HAS[#name[ModuleEngines*]]]
-      {
-        @DATA{
-        
-        PROPELLANT
-        {
-            name = LiquidFuel
-            ratio = 0.9
-        }
-        PROPELLANT
-        {
-            name = Oxidizer
-            ratio = 1.1
-        }
-       }
-      }
-    }        
-  }
-}
+
 
 @PART[bluedog_Titan_Transtage]:HAS[#bdbEngineType[bdbAZ50NTO]]:BEFORE[Bluedog_DB_8]
 {

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Titan_AJ9/TitanIV_Upgrade.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Titan_AJ9/TitanIV_Upgrade.cfg
@@ -1,0 +1,15 @@
+PARTUPGRADE
+{
+	name = AJ11A_Upgrade
+	partIcon = bluedog.LR87.LH2.V
+	techRequired = heavierRocketry
+	entryCost = 6600
+	cost = 0 // for display only; all parts implementing this will need a PartStatsUpgradeModule with cost = this.
+
+	title = Prometheus IV Upgrade
+	real_title = Titan IV Engine upgrade
+	basicInfo = <color=green>Thrust and Isp improvements.</color>
+	manufacturer = Bluedog Design Bureau
+	description = Uupgrades the LR8711 and LR9111 for the Prometheus IV.
+	real_description = Upgrades the LR-91 and LR87 to their AJ-11A subvariants for Titan IV
+}

--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Titan_AJ9/Titan_AJ9.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Titan_AJ9/Titan_AJ9.cfg
@@ -1,6 +1,11 @@
 //An optional patch to add AJ9 subtype to the lr87-AJ5 (closest visual analogue)
+// Major Upgrade to Zorg's origonal AJ9 patch to include the LR87 and LR91 AJ-11.
+// Removal of the LR91-AJ-9 as it is non-distinct, except in bell color from AJ-5 or AJ-7
+// Updated By Pappystein
+// Titan IV Upgrade to unlock these parts are in seperate file in same file folder
 
-@PART[bluedog_LR87_5]:FOR[AJ9Upgrade]
+
+@PART[bluedog_LR87]:FOR[AJ9Upgrade]
 {
 	@tags ^= :$: AJ9:
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
@@ -10,11 +15,13 @@
 			name = LR87-AJ9
 			title =	Prometheus LR8709-948 "Phoebe" Liquid Engine
 			descriptionSummary = Powerful 1.875m engine for the Prometheus-III first stage. Used on the early Prometheus III-C, 23B and 24B.
-			real_title = LR87-AJ9
+			real_title = LR87-AJ-9
 			real_descriptionSummary = Engine for the Titan III-C, 23B and 33B. Replaced subsequently by the AJ11 for later Titan III rockets.
 			descriptionDetail = <b>Thrust:</b> 484.68 kN ASL / 577 kN Vac.\n<b>Isp:</b> 252 s ASL / 300 s Vac.
-			defaultSubtypePriority = 3
+			defaultSubtypePriority = 4
 			addedCost = 220
+			transform = LR87_AJ11_Merged
+			transform = AJ11_Nozzle			
 			upgradeRequired = bluedog_LR87AJ11 //ensures this is unlocked in the same node as Titan III parts
 			MODULE
 			{
@@ -40,11 +47,13 @@
 			name = LR87-AJ9K
 			title =	Prometheus LR8709-948-K "Phoebe" Liquid Engine
 			descriptionSummary = An undertaking by the BDB Special Orders Department to convert the Prometheus II engine back to the non toxic propellants originally used on Prometheus I. Sacrifices some thrust for a small Isp gain.  Powerful 1.875m engine for the Prometheus-III first stage. Used on the early Prometheus III-B & III-C.
-			real_title = LR87-AJ9
+			real_title = LR87-AJ-9K
 			real_descriptionSummary = What if the LR87-AJ-9 had been converted from Hypergolics to non toxic Kerolox like the original Titan I?Engine for the Titan IIIB and IIIC. Replaced subsequently by the AJ11 for later Titan rockets of the 2x modex and latter.
 			descriptionDetail = <b>Thrust:</b> 470.2 kN ASL / 560 kN Vac.\n<b>Isp:</b> 252 s ASL / 300 s Vac.
 			defaultSubtypePriority = 3
 			addedCost = 220
+			transform = LR87_AJ11_Merged
+			transform = AJ11_Nozzle			
 			upgradeRequired = bluedog_LR87AJ11 //ensures this is unlocked in the same node as Titan III parts
 			MODULE
 			{
@@ -64,27 +73,93 @@
 					}
 				}
 			}
+		}
+		SUBTYPE
+		{
+			name = LR87-AJ11AK
+			title =	LR8711-605-AMK "Astreous Majora"
+			descriptionSummary = An undertaking by the BDB Special Orders Department to convert the Prometheus IV engine back to the non toxic propellants originally used on Prometheus I. Sacrifices some thrust for a small Isp gain. Air-lit variant with altitude optimized nozzle.  \nDue to design and production delays only flew in the 2nd and latter production lots of the Prometheus-IV
+			real_title = LR87-AJ-11AK
+			real_descriptionSummary = LR87-AJ-11A, just designed to run on less toxic Kerolox like the original Titan I Engine for the Titan IV.  An air ignited variant.  Arrived mid Titan IV Launch cycle due to design and purchase delays.
+			descriptionDetail = <b>Thrust:</b> 470.2 kN ASL / 578 kN Vac.\n<b>Isp:</b> 252 s ASL / 312 s Vac.
+			defaultSubtypePriority = 3
+			addedCost = 220			
+			transform = LR87_AJ11_Merged
+			transform = AJ11A_Nozzle
+			upgradeRequired = bluedog_LR87AJ11 //ensures this is unlocked in the same node as Titan III parts
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+				}
+
+				DATA
+				{
+					maxThrust = 578
+					atmosphereCurve
+					{
+						key = 0 312
+						key = 1 252
+						key = 6 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = LR87-AJ11A
+			title =	LR8711-608-AM "Astreous Majora"
+			descriptionSummary = Air Lit main engine for the Prometheus-IV with altitude optimized nozzle.  Due to design and production delays only flew in the 2nd and latter production lots of the Prometheus-IV
+			real_title = LR87-AJ-11A
+			real_descriptionSummary = The intended LR87 for the Titan IV rocket. Due to production delays, did not fly with the first production batch of Titan IVs.  Air lit and optimized for standard Titan IV launch profile.  \nUtilize the <b>LR87-AJ-11-1</b> if you want the engine igniting on the ground.
+			descriptionDetail = <b>Thrust:</b> 470.2 kN ASL / 607.4 kN Vac.\n<b>Isp:</b> 252 s ASL / 300 s Vac.
+			defaultSubtypePriority = 3
+			addedCost = 220
+			transform = LR87_AJ11_Merged
+			transform = AJ11A_Nozzle			
+			upgradeRequired = AJ11A_Upgrade //Ensures this unlocks with SMRU and not earlier.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+				}
+
+				DATA
+				{
+					maxThrust = 607.4
+					atmosphereCurve
+					{
+						key = 0 308
+						key = 1 245
+						key = 6 0.001
+					}
+				}
+			}
 		}		
 	}
 }
-//An optional patch to add AJ9 subtype to the lr91-AJ5 (closest visual analogue)
 
-@PART[bluedog_LR91_5]:FOR[AJ9Upgrade]
+//Update to the LR91 upgrade removing the identical LR91-AJ-9 (as it is the same as the LR91-AJ-5/-7 engines in everything but color)
+
+@PART[bluedog_LR91]:FOR[AJ9Upgrade]
 {
 	@tags ^= :$: AJ9:
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]
 	{
 		SUBTYPE
 		{
-			name = LR91-AJ9
-			title =	Prometheus LR9109-948 "Phoebe" Liquid Engine
-			descriptionSummary =   Powerful 1.875m engine for the Prometheus-III first stage. Used on the early Prometheus III-B & III-C.
-			real_title = LR91-AJ9
-			real_descriptionSummary = Engine for the Titan IIIB and IIIC. Replaced subsequently by the AJ11 for later Titan rockets of the 2x modex and latter.
+			name = LR91-AJ11A
+			title =	Prometheus LR9111-177M "Asteria Majora" Liquid Engine
+			descriptionSummary =   1.875m second stage engine for the Prometheus-IV rocket, entered production too late for early Prometheus-IV launches.
+			real_title = LR91-AJ-11A
+			real_descriptionSummary = Engine for the Titan IV. While meant to fly on all Titan IV launches a production delay led to the re-use of the earlier AJ-11 subvariant early in the Titan IV launch schedule.
 			descriptionDetail = <b>Thrust:</b> 89.52 kN ASL / 112.25 kN Vac.\n<b>Isp:</b> 172 s ASL / 316 s Vac.
-			defaultSubtypePriority = 3
+			defaultSubtypePriority = 9
 			addedCost = 110
-			upgradeRequired = bluedog_LR87AJ11 //ensures this is unlocked in the same node as Titan III parts
+			transform = Titan2_LR91AJ11 (2)			
+			upgradeRequired = AJ11A_Upgrade //ensures this is unlocked in the same node as Titan III parts
 			MODULE
 			{
 				IDENTIFIER
@@ -94,27 +169,46 @@
 				}
 				DATA
 				{
-					maxThrust = 112.25
+					maxThrust = 118.5
 					atmosphereCurve
 					{
-						key = 0 316
-						key = 1 172
+						key = 0 318
+						key = 1 170
 						key = 5 0.001
 					}
 				}
 			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+					engineID = vernier
+				}
+				DATA
+				{
+					runningEffectName = running_kerolox_vernier
+					atmosphereCurve
+					{
+						key = 0 325
+						key = 1 163
+						key = 3 0.001
+					}
+				}
+			}			
 		}
 		SUBTYPE
 		{
-			name = LR91-AJ9K
-			title =	Prometheus LR9109-948-K "Phoebe" Liquid Engine
-			descriptionSummary = An undertaking by the BDB Special Orders Department to convert the Prometheus II engines back to the non toxic propellants originally used on Prometheus I. Sacrifices some thrust for a small Isp gain. Used on the early Prometheus III-C, 23B and 24B.
-			real_title = LR91-AJ9
-			real_descriptionSummary = Engine for the Titan III-C, 23B and 33B. Replaced subsequently by the AJ11 for later Titan III rockets.
+			name = LR91-AJ11AK
+			title =	Prometheus LR9111-177M-K "Asteria Majora" Liquid Engine
+			descriptionSummary = An undertaking by the BDB Special Orders Department to convert the Prometheus IV engines back to the non toxic propellants originally used on Prometheus I. Sacrifices some thrust for a small Isp gain. Due to production delay only flew on latter Prometheus-IV rockets.
+			real_title = LR91-AJ-11AK
+			real_descriptionSummary = Lower toxicity Kero-Lox Engine for the Titan IV. While meant to fly on all Titan IV launches a production delay led to the re-use of the earlier AJ-11 subvariant early in the Titan IV launch schedule.
 			descriptionDetail = <b>Thrust:</b> 89.52 kN ASL / 109.33 kN Vac.\n<b>Isp:</b> 172 s ASL / 316 s Vac.
-			defaultSubtypePriority = 3
+			defaultSubtypePriority = 8
 			addedCost = 110
-			upgradeRequired = bluedog_LR87AJ11 //ensures this is unlocked in the same node as Titan III parts
+			transform = Titan2_LR91AJ11 (2)			
+			upgradeRequired = AJ11A_Upgrade //ensures this is unlocked in the same node as Titan III parts
 			MODULE
 			{
 				IDENTIFIER
@@ -124,15 +218,133 @@
 				}
 				DATA
 				{
-					maxThrust = 106.33
+					maxThrust = 112.2
 					atmosphereCurve
 					{
-						key = 0 332
-						key = 1 158
+						key = 0 333
+						key = 1 154
 						key = 5 0.001
 					}
 				}
 			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+					engineID = vernier
+				}
+				DATA
+				{
+					runningEffectName = running_kerolox_vernier
+					atmosphereCurve
+					{
+						key = 0 325
+						key = 1 163
+						key = 3 0.001
+					}
+				}
+			}			
 		}
+		SUBTYPE
+		{
+			name = LR91-AJ11AQ
+			title =	Prometheus LR9111-177MQ "Asteria Majora" Liquid Engine with quad verniers
+			descriptionSummary =   1.875m second stage engine for the Prometheus-IV rocket, entered production too late for early Prometheus-IV launches.  Now includes quad vernier thrusters for the ultimate stage control.
+			real_title = LR91-AJ-11(V)4A
+			real_descriptionSummary = Final Titan IV 2nd stage engine.  With quad verniers like the original Titan I AJ-3 variant.   
+			descriptionDetail = <b>Thrust:</b> 89.52 kN ASL / 112.25 kN Vac.\n<b>Isp:</b> 172 s ASL / 316 s Vac.
+			defaultSubtypePriority = 10
+			addedCost = 110
+			transform = LR91_AJ11_FourNernier			
+			upgradeRequired = AJ11A_Upgrade //ensures this is unlocked in the same node as Titan III parts
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+					thrustVectorTransformName = thrustTransform
+				}
+				DATA
+				{
+					maxThrust = 118.5
+					atmosphereCurve
+					{
+						key = 0 318
+						key = 1 170
+						key = 5 0.001
+					}
+				}
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+					engineID = vernier
+				}
+				DATA
+				{
+					thrustVectorTransformName = vernierTransform
+					runningEffectName = running_4vernier
+					atmosphereCurve
+					{
+						key = 0 325
+						key = 1 163
+						key = 3 0.001
+					}
+				}
+			}			
+		}
+		SUBTYPE
+		{
+			name = LR91-AJ11AQK
+			title =	Prometheus LR9111-177MQK "Asteria Majora" Liquid Engine
+			descriptionSummary = An undertaking by the BDB Special Orders Department to convert the Prometheus IV engines back to the non toxic propellants.  1.875m second stage engine for the Prometheus-IV rocket, entered production too late for early Prometheus-IV launches.  Now includes quad vernier thrusters for the ultimate stage control.
+			real_title = LR91-AJ-11(V)4AK
+			real_descriptionSummary = Low toxicity Titan IV 2nd stage engine.  With quad verniers like the original Titan I AJ-3 variant.
+			descriptionDetail = <b>Thrust:</b> 89.52 kN ASL / 109.33 kN Vac.\n<b>Isp:</b> 172 s ASL / 316 s Vac.
+			defaultSubtypePriority = 11
+			addedCost = 110
+			transform = LR91_AJ11_FourNernier
+			upgradeRequired = AJ11A_Upgrade //ensures this is unlocked in the same node as Titan III parts
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+					thrustVectorTransformName = thrustTransform
+				}
+				DATA
+				{
+					maxThrust = 112.2
+					atmosphereCurve
+					{
+						key = 0 333
+						key = 1 154
+						key = 5 0.001
+					}
+				}
+			}
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+					engineID = vernier
+				}
+				DATA
+				{
+					thrustVectorTransformName = vernierTransform
+					runningEffectName = running_kerolox_4vernier
+					atmosphereCurve
+					{
+						key = 0 325
+						key = 1 163
+						key = 3 0.001
+					}
+				}
+			}			
+		}		
 	}
 }


### PR DESCRIPTION
Patch to bring Hypergolic back to BDB

Adds 1 new file (Titan IV Upgrade for AJ11A engines) 

Significantly alters the Titan AJ-9 file origionally made by Zorg

Completely rebuilds "Titan Fuel Switching" and removes Titan Engines from BDB_Hypergolic_Update

Once the Titan Fuel tanks are merged a minor edit will need to be made in the file BDB_HypergolicUpdate