### PR TITLE
Full Probe swap to Hypergolic

### DIFF
--- a/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/BDB_HypergolicUpdate.cfg
+++ b/BD_Extras (No Warranty)/GameData/Bluedog_DB_Extras/Pafftek/HypergolicBDB/BDB_HypergolicUpdate.cfg
@@ -81,6 +81,16 @@
 	%bdbTankType = Hypergolic
 }	
 
+/// Gemini lander
+@PART[bluedog_Gemini_Lander_Frame,bluedog_Gemini_Lander_SaddleTank]:NEEDS[!SkyhawkScienceSystem]:First
+{
+	%bdbTankType = Hypergolic
+}
+@PART[bluedog_Gemini_Lander_Engine]:NEEDS[!SkyhawkScienceSystem]:First
+{
+	%bdbEngineType = bdbAZ50NTO
+}
+
 // Other
 @PART[bluedog_C1engine]:NEEDS[!SkyhawkScienceSystem]:First
 {
@@ -96,6 +106,14 @@
 	%bdbEngineType = bdbAZ50NTO
 }
 @PART[bluedog_Mariner71_PropulsionModule]:NEEDS[!SkyhawkScienceSystem]:First
+{
+	%bdbEngineType = bdbAZ50NTO
+}
+@PART[bluedog_Clementine_Bus,bluedog_SurveyorOrbiter_Core,bluedog_Surveyor_Core]:NEEDS[!SkyhawkScienceSystem]:First
+{
+	%bdbTankType = Hypergolic
+}
+@PART[bluedog_Clementine_Engine,bluedog_Ranger_Lander_Propulsion,bluedog_Surveyor_Vernier]:NEEDS[!SkyhawkScienceSystem]:First
 {
 	%bdbEngineType = bdbAZ50NTO
 }


### PR DESCRIPTION
Updates all LF/O probes to Hypergolic

All updates are in either // Gemini or // Probes go here sections of the file


Gemini Lander has been re-fueled with Hypergolic patch and verified on Kerbin (utilizing less than full load) both MechEngineer and MechJeb state should work fine on mun and minimus.   Should provide slightly better window of operation

every probe and Engine with LiquidFuel and Oxidizer in it was converted to Hypergolic.   This applies to the Probe expansion folder only.