### PR TITLE
[EngineIgnitor] fix for remaining ignitions having a higher value than available ignitions on some engine configs

### DIFF
--- a/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Able.cfg
+++ b/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Able.cfg
@@ -26,6 +26,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 1
 					IgnitionsRemained = 1
 				}
 			}
@@ -40,6 +41,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 1
 					IgnitionsRemained = 1
 				}
 			}
@@ -54,6 +56,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 1000
 					IgnitionsRemained = 1000
 				}
 			}
@@ -68,6 +71,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 1000
 					IgnitionsRemained = 1000
 				}
 			}

--- a/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Agena.cfg
+++ b/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Agena.cfg
@@ -27,6 +27,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 1
 					IgnitionsRemained = 1
 					UseUllageSimulation = true
 				}
@@ -42,6 +43,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 2
 					IgnitionsRemained = 2
 					UseUllageSimulation = true
 				}
@@ -57,6 +59,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 15
 					IgnitionsRemained = 15 //assuming GATV configuration. Regular version was 3
 					UseUllageSimulation = false
 				}
@@ -72,6 +75,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 15
 					IgnitionsRemained = 15 //Would have actually been 3 but probably not good to downgrade. So keeping it same as GATV
 					UseUllageSimulation = false
 				}
@@ -87,6 +91,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 200
 					IgnitionsRemained = 200 // https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024172.pdf 200 starts planned
 					UseUllageSimulation = false
 				}
@@ -102,6 +107,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 200
 					IgnitionsRemained = 200 //assuming same as the 8096B at least
 					UseUllageSimulation = false
 				}

--- a/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Centaur.cfg
+++ b/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Centaur.cfg
@@ -25,6 +25,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 10
 					IgnitionsRemained = 10
 				}
 			}
@@ -39,6 +40,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 10
 					IgnitionsRemained = 10
 				}
 			}
@@ -53,6 +55,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 10
 					IgnitionsRemained = 10
 				}
 			}
@@ -67,6 +70,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 10
 					IgnitionsRemained = 10
 				}
 			}
@@ -81,6 +85,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 10
 					IgnitionsRemained = 10
 				}
 			}
@@ -95,6 +100,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 10
 					IgnitionsRemained = 10
 				}
 			}
@@ -109,6 +115,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 10
 					IgnitionsRemained = 10
 				}
 			}
@@ -123,6 +130,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 15
 					IgnitionsRemained = 15
 				}
 			}

--- a/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Saturn.cfg
+++ b/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Saturn.cfg
@@ -59,8 +59,8 @@
 				}
 				DATA
 				{
-					IgnitionsAvailable = 3
-					IgnitionsRemained = 3
+					IgnitionsAvailable = 2
+					IgnitionsRemained = 2
 				}
 			}
 		}

--- a/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Saturn.cfg
+++ b/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Saturn.cfg
@@ -41,6 +41,7 @@
 	{
 		name = ModuleEngineIgnitor
 		IgnitionsAvailable = 3
+		IgnitionsRemained = 3
 		AutoIgnitionTemperature = 650
 
 		UseUllageSimulation = true
@@ -58,7 +59,8 @@
 				}
 				DATA
 				{
-					IgnitionsRemained = 2
+					IgnitionsAvailable = 3
+					IgnitionsRemained = 3
 				}
 			}
 		}
@@ -72,6 +74,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 3
 					IgnitionsRemained = 3
 				}
 			}
@@ -86,6 +89,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 2
 					IgnitionsRemained = 2
 				}
 			}
@@ -100,6 +104,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 6
 					IgnitionsRemained = 6
 				}
 			}
@@ -114,6 +119,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 6
 					IgnitionsRemained = 6
 				}
 			}
@@ -128,6 +134,7 @@
 				}
 				DATA
 				{
+					IgnitionsAvailable = 6
 					IgnitionsRemained = 6
 				}
 			}

--- a/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Thor.cfg
+++ b/GameData/Bluedog_DB/Compatibility/EngineIgnitor/EI_Thor.cfg
@@ -29,6 +29,7 @@
 
 				DATA
 				{
+					IgnitionsAvailable = 1
 					IgnitionsRemained = 1
 				}
 			}


### PR DESCRIPTION
also wasn't sure why the base J2 config had only 2 available ignitions so I've bumped it back up to 3