### PR TITLE
Fix SRB negative dry mass on rescaled system

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
@@ -362,6 +362,14 @@ BDBRESCALECONFIG
 {
 	@mass *= #$@BDBRESCALECONFIG/tankFactor$
 	%bdbMassAdjusted = #$@BDBRESCALECONFIG/tankFactor$
+	
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@addedMass *= #$@BDBRESCALECONFIG/tankFactor$
+		}
+	}
 }
 
 //@PART[bluedog*,Bluedog*]:HAS[#bdbSystemScale[>1],@MODULE[ModuleEngines*]:HAS[@PROPELLANT[SolidFuel]],~bdbSrbAdjusted[*]]:FOR[zzzBluedog_DB_5]


### PR DESCRIPTION
Fixed an issue with some SRB variants eg. UA1202 having negative dry mass on upscaled system. The original patch was adjusting only base variant dry mass and not other B9PartSwitch variants.