### PR TITLE
Add support for Sol Quarter Scale scaling

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
@@ -48,6 +48,7 @@ BDBRESCALECONFIG
 {
     @systemScale = 2.5
 }
+
 @BDBRESCALECONFIG:NEEDS[SolSystem]:FOR[zzzBluedog_DB_0]
 {
     Sol_Configuration
@@ -55,10 +56,9 @@ BDBRESCALECONFIG
         SystemScale = #$@Sol_Configuration/SystemScale$
     }
 }
-
 @BDBRESCALECONFIG:NEEDS[SolSystem]:HAS[@Sol_Configuration:HAS[#SystemScale[Quarter]]]:FOR[zzzBluedog_DB_0]
 {
-    @systemScale = 2.5
+    @systemScale = 2.65
 }
 
 @BDBRESCALECONFIG:NEEDS[JNSQ]:FOR[zzzBluedog_DB_0]

--- a/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/Rescale/BlueSmurff.cfg
@@ -48,12 +48,23 @@ BDBRESCALECONFIG
 {
     @systemScale = 2.5
 }
+@BDBRESCALECONFIG:NEEDS[SolSystem]:FOR[zzzBluedog_DB_0]
+{
+    Sol_Configuration
+    {
+        SystemScale = #$@Sol_Configuration/SystemScale$
+    }
+}
+
+@BDBRESCALECONFIG:NEEDS[SolSystem]:HAS[@Sol_Configuration:HAS[#SystemScale[Quarter]]]:FOR[zzzBluedog_DB_0]
+{
+    @systemScale = 2.5
+}
 
 @BDBRESCALECONFIG:NEEDS[JNSQ]:FOR[zzzBluedog_DB_0]
 {
     @systemScale = 2.7
 }
-
 
 @BDBRESCALECONFIG:HAS[#systemScale[>6.4]]:BEFORE[zzzBluedog_DB_1]
 {


### PR DESCRIPTION
Set systemScale to 2.5 if SolSystem is present and configuration is set to Quarter.
Do not adjust for real scale as adjustments are not valid beyond 6.4